### PR TITLE
refactor: get rid of indexing and slicing in check_armored_payload()

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -116,7 +116,7 @@ pub fn check_encrypted(mail: &mailparse::ParsedMail, outgoing: bool) -> bool {
                     return false;
                 }
             };
-            if !check_armored_payload(payload, outgoing) {
+            if !check_armored_payload(&payload, outgoing) {
                 log::debug!("check_encrypted: armored payload check failed");
                 return false;
             }


### PR DESCRIPTION
Indexing can potentially panic, without indexing
it is easier to make sure there will be no crash.