### PR TITLE
chore(dist): Switch to musl targets

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,4 +8,4 @@ cargo-dist-version = "0.30.3"
 # The installers to generate for each app
 installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
+targets = ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Ensures filtermail binaries are 100% statically linked.