### PR TITLE
refactor: Remove unnecessary Arc

### DIFF
--- a/src/inbound.rs
+++ b/src/inbound.rs
@@ -7,21 +7,18 @@ use crate::smtp_server::SmtpHandler;
 use async_trait::async_trait;
 use lettre::{AsyncSmtpTransport, AsyncTransport, Tokio1Executor};
 use mailparse::{MailHeaderMap, parse_mail};
-use std::sync::Arc;
 
 pub use crate::smtp_server::Envelope;
 use crate::utils::{extract_address, format_smtp_error};
 
 /// Handler for incoming SMTP messages.
 pub struct IncomingBeforeQueueHandler {
-    config: Arc<Config>,
+    config: Config,
 }
 
 impl IncomingBeforeQueueHandler {
     pub fn new(config: Config) -> Self {
-        Self {
-            config: Arc::new(config),
-        }
+        Self { config }
     }
 }
 

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -10,11 +10,10 @@ use async_trait::async_trait;
 use governor::{DefaultKeyedRateLimiter, Quota, RateLimiter};
 use lettre::{AsyncSmtpTransport, AsyncTransport, Tokio1Executor};
 use mailparse::{MailHeaderMap, parse_mail};
-use std::sync::Arc;
 
 /// Handler for outgoing SMTP messages.
 pub struct OutgoingBeforeQueueHandler {
-    config: Arc<Config>,
+    config: Config,
     send_rate_limiter: DefaultKeyedRateLimiter<String>,
 }
 
@@ -23,7 +22,7 @@ impl OutgoingBeforeQueueHandler {
         let quota = Quota::per_minute(config.max_user_send_per_minute)
             .allow_burst(config.max_user_send_burst_size);
         Self {
-            config: Arc::new(config),
+            config,
             send_rate_limiter: RateLimiter::keyed(quota),
         }
     }


### PR DESCRIPTION
`Arc` around handler configs are not needed,
as they are not shared.