### PR TITLE
chore(ci): Add missing Zig dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           toolchain: stable
           targets: aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
       - uses: taiki-e/install-action@71b48393496777ee11188c07a34d48b048a985cd # v2
         with:
           tool: cargo-zigbuild


### PR DESCRIPTION
I forgot to add setup-zig (zigbuild obviously requires zig).

Tested locally with act, it now builds properly.