### PR TITLE
chore(ci): Fix binary publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,8 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           mkdir dist
-          mv filtermail-x86_64 dist/filtermail-x86_64
-          mv filtermail-aarch64 dist/filtermail-aarch64
+          mv filtermail-x86_64/filtermail dist/filtermail-x86_64
+          mv filtermail-aarch64/filtermail dist/filtermail-aarch64
           gh release upload "$REF_NAME" \
             --repo ${{ github.repository }} \
             dist/*


### PR DESCRIPTION
The binaries were built properly, but publish job failed... I will just download the artifacts and upload them there manually this time. This should fix it for the future releases.