### PR TITLE
refactor: use enum for mode cli arg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,18 @@ enum Mode {
     Incoming,
 }
 
+impl std::str::FromStr for Mode {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "outgoing" => Ok(Mode::Outgoing),
+            "incoming" => Ok(Mode::Incoming),
+            _ => Err("Error: mode must be 'incoming' or 'outgoing'"),
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() {
     // default to info level
@@ -78,11 +90,10 @@ async fn main() {
         unreachable!("args length checked above")
     };
 
-    let mode = match &**mode {
-        "outgoing" => Mode::Outgoing,
-        "incoming" => Mode::Incoming,
-        _ => {
-            eprintln!("Error: mode must be 'incoming' or 'outgoing'");
+    let mode = match mode.parse::<Mode>() {
+        Ok(mode) => mode,
+        Err(e) => {
+            eprintln!("{e}");
             process::exit(1);
         }
     };


### PR DESCRIPTION
A small code style change replacing `mode` string comparison (more of a Python-way thing) with an enum.

The problem is that `mode` gets compared twice, when validating its value and, next, when deciding what server to start. We should either define a constant, or simply parse the string only once and operate with an internal representation (this PR is the second approach)