### PR TITLE
feat: configurable hosts for listen and reinject

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ item may start with `@` to whitelist whole recipient domains.
 - `mailboxes_dir` - path to mailboxes directory,
 defaults to `/home/vmail/mail/<mail_domain>`.
 
+The following options are Filtermail-specific,
+they are not read by other chatmail relay components
+and usually does not need to be set at all:
+
+- `filtermail_host` - IP address to listen on,
+defaults to `127.0.0.1`.
+- `postfix_host` - hostname or IP address where postfix is set up,
+a host is resolved only on Filtermail startup,
+useful in case MTA runs somewhere outside of localhost,
+defaults to `127.0.0.1`.
+
 ### Environment variables
 
 Additional options that can be set using environment variables:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ defaults to `/home/vmail/mail/<mail_domain>`.
 
 The following options are Filtermail-specific,
 they are not read by other chatmail relay components
-and usually does not need to be set at all:
+and usually do not need to be set at all:
 
 - `filtermail_host` - IP address to listen on,
 defaults to `127.0.0.1`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,8 +123,10 @@ impl Default for Config {
     /// Used for tests.
     fn default() -> Self {
         Self {
+            filtermail_host: Self::default_filtermail_host(),
             filtermail_smtp_port: Self::default_filtermail_smtp_port(),
             filtermail_smtp_port_incoming: Self::default_filtermail_smtp_port_incoming(),
+            postfix_host: Self::default_postfix_host(),
             postfix_reinject_port: Self::default_postfix_reinject_port(),
             postfix_reinject_port_incoming: Self::default_postfix_reinject_port_incoming(),
             max_message_size: Self::default_max_message_size(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,14 +8,14 @@ use std::path::{Path, PathBuf};
 /// Chatmail configuration subset used by filtermail.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
-    #[serde(default = "Config::default_filtermail_smtp_host")]
-    pub filtermail_smtp_host: IpAddr,
+    #[serde(default = "Config::default_filtermail_host")]
+    pub filtermail_host: IpAddr,
     #[serde(default = "Config::default_filtermail_smtp_port")]
     pub filtermail_smtp_port: u16,
     #[serde(default = "Config::default_filtermail_smtp_port_incoming")]
     pub filtermail_smtp_port_incoming: u16,
-    #[serde(default = "Config::default_postfix_reinject_host")]
-    pub postfix_reinject_host: String,
+    #[serde(default = "Config::default_postfix_host")]
+    pub postfix_host: String,
     #[serde(default = "Config::default_postfix_reinject_port")]
     pub postfix_reinject_port: u16,
     #[serde(default = "Config::default_postfix_reinject_port_incoming")]
@@ -87,7 +87,7 @@ impl Config {
 
     // Following are needed since serde does not support default literals.
 
-    const fn default_filtermail_smtp_host() -> IpAddr {
+    const fn default_filtermail_host() -> IpAddr {
         IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
     }
     const fn default_filtermail_smtp_port() -> u16 {
@@ -96,7 +96,7 @@ impl Config {
     const fn default_filtermail_smtp_port_incoming() -> u16 {
         10081
     }
-    fn default_postfix_reinject_host() -> String {
+    fn default_postfix_host() -> String {
         "127.0.0.1".to_owned()
     }
     const fn default_postfix_reinject_port() -> u16 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,16 +1,21 @@
 //! Configuration file handling for filtermail.
 
 use serde::{Deserialize, Deserializer};
+use std::net::IpAddr;
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 
 /// Chatmail configuration subset used by filtermail.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
+    #[serde(default = "Config::default_filtermail_smtp_host")]
+    pub filtermail_smtp_host: IpAddr,
     #[serde(default = "Config::default_filtermail_smtp_port")]
     pub filtermail_smtp_port: u16,
     #[serde(default = "Config::default_filtermail_smtp_port_incoming")]
     pub filtermail_smtp_port_incoming: u16,
+    #[serde(default = "Config::default_postfix_reinject_host")]
+    pub postfix_reinject_host: String,
     #[serde(default = "Config::default_postfix_reinject_port")]
     pub postfix_reinject_port: u16,
     #[serde(default = "Config::default_postfix_reinject_port_incoming")]
@@ -82,11 +87,17 @@ impl Config {
 
     // Following are needed since serde does not support default literals.
 
+    const fn default_filtermail_smtp_host() -> IpAddr {
+        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+    }
     const fn default_filtermail_smtp_port() -> u16 {
         10080
     }
     const fn default_filtermail_smtp_port_incoming() -> u16 {
         10081
+    }
+    fn default_postfix_reinject_host() -> String {
+        "127.0.0.1".to_owned()
     }
     const fn default_postfix_reinject_port() -> u16 {
         10025

--- a/src/inbound.rs
+++ b/src/inbound.rs
@@ -22,10 +22,8 @@ pub struct IncomingBeforeQueueHandler {
 
 impl IncomingBeforeQueueHandler {
     pub fn new(config: Config, skip_dkim: bool) -> Result<Self, crate::error::Error> {
-        let reinject_addr = crate::resolve_addr(
-            &config.postfix_reinject_host,
-            config.postfix_reinject_port_incoming,
-        )?;
+        let reinject_addr =
+            crate::resolve_addr(&config.postfix_host, config.postfix_reinject_port_incoming)?;
         Ok(Self {
             config,
             dkim_verifier: DkimVerifier::new()?,

--- a/src/inbound.rs
+++ b/src/inbound.rs
@@ -9,6 +9,7 @@ use crate::smtp_server::SmtpHandler;
 use crate::utils::{AddressDomain, extract_address, log_eml};
 use async_trait::async_trait;
 use mailparse::{MailHeaderMap, parse_mail};
+use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
 /// Handler for incoming SMTP messages.
@@ -16,14 +17,21 @@ pub struct IncomingBeforeQueueHandler {
     config: Config,
     dkim_verifier: DkimVerifier,
     skip_dkim: bool,
+    reinject_addr: SocketAddr,
 }
 
 impl IncomingBeforeQueueHandler {
-    pub fn new(config: Config, skip_dkim: bool) -> Result<Self, crate::error::Error> {
+    pub fn new(
+        config: Config,
+        skip_dkim: bool,
+        postfix_host: IpAddr,
+    ) -> Result<Self, crate::error::Error> {
+        let reinject_addr = SocketAddr::new(postfix_host, config.postfix_reinject_port_incoming);
         Ok(Self {
             config,
             dkim_verifier: DkimVerifier::new()?,
             skip_dkim,
+            reinject_addr,
         })
     }
 
@@ -134,7 +142,7 @@ impl SmtpHandler for IncomingBeforeQueueHandler {
     async fn reinject_mail(&self, envelope: &Envelope) -> Result<(), String> {
         log::debug!("Re-injecting the mail that passed checks");
 
-        crate::smtp_client::send(self.config.postfix_reinject_port_incoming, envelope)
+        crate::smtp_client::send(self.reinject_addr, envelope)
             .await
             .map_err(|e| {
                 log::warn!("Failed to re-inject mail: {}", e);

--- a/src/inbound.rs
+++ b/src/inbound.rs
@@ -9,7 +9,7 @@ use crate::smtp_server::SmtpHandler;
 use crate::utils::{AddressDomain, extract_address, log_eml};
 use async_trait::async_trait;
 use mailparse::{MailHeaderMap, parse_mail};
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::str::FromStr;
 
 /// Handler for incoming SMTP messages.
@@ -21,12 +21,11 @@ pub struct IncomingBeforeQueueHandler {
 }
 
 impl IncomingBeforeQueueHandler {
-    pub fn new(
-        config: Config,
-        skip_dkim: bool,
-        postfix_host: IpAddr,
-    ) -> Result<Self, crate::error::Error> {
-        let reinject_addr = SocketAddr::new(postfix_host, config.postfix_reinject_port_incoming);
+    pub fn new(config: Config, skip_dkim: bool) -> Result<Self, crate::error::Error> {
+        let reinject_addr = crate::resolve_addr(
+            &config.postfix_reinject_host,
+            config.postfix_reinject_port_incoming,
+        )?;
         Ok(Self {
             config,
             dkim_verifier: DkimVerifier::new()?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ async fn main() {
 }
 
 fn resolve_addr(host: &str, port: u16) -> Result<SocketAddr, error::Error> {
-    log::info!("Resolving {host}");
+    log::debug!("Resolving {host}");
     Ok((host, port)
         .to_socket_addrs()?
         .next()

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ use inbound::IncomingBeforeQueueHandler;
 use outbound::OutgoingBeforeQueueHandler;
 use smtp_server::run_smtp_server;
 use std::env;
-use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::process;
 use std::sync::Arc;
 
@@ -86,21 +86,10 @@ async fn main() {
         }
     };
 
-    let listen =
-        env::var("LISTEN_IP").map_or(Ipv4Addr::LOCALHOST.into(), |s| match s.parse::<IpAddr>() {
-            Ok(ip) => ip,
-            Err(e) => {
-                eprintln!("Cannot parse listen address: {e}");
-                process::exit(1);
-            }
-        });
-
-    let postfix =
-        env::var("POSTFIX_HOST").map_or(Ipv4Addr::LOCALHOST.into(), |s| resolve_postfix_host(&s));
-
+    let host = config.filtermail_smtp_host;
     if mode == "outgoing" {
-        let addr = (listen, config.filtermail_smtp_port);
-        let handler = Arc::new(OutgoingBeforeQueueHandler::new(config.clone(), postfix));
+        let addr = (host, config.filtermail_smtp_port);
+        let handler = Arc::new(OutgoingBeforeQueueHandler::new(config.clone()).unwrap());
         let max_size = config.max_message_size;
         log::debug!("Outgoing SMTP server listening on {}:{}", addr.0, addr.1);
 
@@ -118,10 +107,10 @@ async fn main() {
             log::warn!("DKIM verification DISABLED! This should not be used in production.");
         }
 
-        let addr = (listen, config.filtermail_smtp_port_incoming);
+        let addr = (host, config.filtermail_smtp_port_incoming);
         let handler = Arc::new(
             // We want to panic here if the handler cannot be created.
-            IncomingBeforeQueueHandler::new(config.clone(), skip_dkim, postfix).unwrap(),
+            IncomingBeforeQueueHandler::new(config.clone(), skip_dkim).unwrap(),
         );
         let max_size = config.max_message_size;
         log::debug!("Incoming SMTP server listening on {}:{}", addr.0, addr.1);
@@ -133,18 +122,10 @@ async fn main() {
     }
 }
 
-fn resolve_postfix_host(s: &str) -> IpAddr {
-    match (s, 0).to_socket_addrs() {
-        Ok(mut addrs) => match addrs.next() {
-            Some(addr) => addr.ip(),
-            None => {
-                eprintln!("Cannot resolve postfix host");
-                process::exit(1);
-            }
-        },
-        Err(e) => {
-            eprintln!("Cannot resolve postfix host: {e}");
-            process::exit(1);
-        }
-    }
+fn resolve_addr(host: &str, port: u16) -> Result<SocketAddr, error::Error> {
+    log::info!("Resolving {host}");
+    Ok((host, port)
+        .to_socket_addrs()?
+        .next()
+        .ok_or(std::io::Error::other("Cannot resolve host"))?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ use inbound::IncomingBeforeQueueHandler;
 use outbound::OutgoingBeforeQueueHandler;
 use smtp_server::run_smtp_server;
 use std::env;
-use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use std::net::{SocketAddr, ToSocketAddrs};
 use std::process;
 use std::sync::Arc;
 
@@ -107,9 +107,8 @@ async fn main() {
         }
     };
 
-    let host = config.filtermail_smtp_host;
     if mode == Mode::Outgoing {
-        let addr = (host, config.filtermail_smtp_port);
+        let addr = (config.filtermail_host, config.filtermail_smtp_port);
         let handler = Arc::new(OutgoingBeforeQueueHandler::new(config.clone()).unwrap());
         let max_size = config.max_message_size;
         log::debug!("Outgoing SMTP server listening on {}:{}", addr.0, addr.1);
@@ -128,7 +127,7 @@ async fn main() {
             log::warn!("DKIM verification DISABLED! This should not be used in production.");
         }
 
-        let addr = (host, config.filtermail_smtp_port_incoming);
+        let addr = (config.filtermail_host, config.filtermail_smtp_port_incoming);
         let handler = Arc::new(
             // We want to panic here if the handler cannot be created.
             IncomingBeforeQueueHandler::new(config.clone(), skip_dkim).unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,11 +85,21 @@ async fn main() {
         }
     };
 
+    let listen = env::var("LISTEN_IP").map_or(std::net::Ipv4Addr::LOCALHOST.into(), |s| {
+        match s.parse::<std::net::IpAddr>() {
+            Ok(ip) => ip,
+            Err(e) => {
+                eprintln!("Cannot parse listen address: {e}");
+                process::exit(1);
+            }
+        }
+    });
+
     if mode == "outgoing" {
+        let addr = (listen, config.filtermail_smtp_port);
         let handler = Arc::new(OutgoingBeforeQueueHandler::new(config.clone()));
-        let addr = format!("127.0.0.1:{}", config.filtermail_smtp_port);
         let max_size = config.max_message_size;
-        log::debug!("Outgoing SMTP server listening on {addr}");
+        log::debug!("Outgoing SMTP server listening on {}:{}", addr.0, addr.1);
 
         if let Err(e) = run_smtp_server(&addr, handler, max_size).await {
             eprintln!("Server error: {}", e);
@@ -105,13 +115,13 @@ async fn main() {
             log::warn!("DKIM verification DISABLED! This should not be used in production.");
         }
 
+        let addr = (listen, config.filtermail_smtp_port_incoming);
         let handler = Arc::new(
             // We want to panic here if the handler cannot be created.
             IncomingBeforeQueueHandler::new(config.clone(), skip_dkim).unwrap(),
         );
-        let addr = format!("127.0.0.1:{}", config.filtermail_smtp_port_incoming);
         let max_size = config.max_message_size;
-        log::debug!("Incoming SMTP server listening on {addr}");
+        log::debug!("Incoming SMTP server listening on {}:{}", addr.0, addr.1);
 
         if let Err(e) = run_smtp_server(&addr, handler, max_size).await {
             eprintln!("Server error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ use inbound::IncomingBeforeQueueHandler;
 use outbound::OutgoingBeforeQueueHandler;
 use smtp_server::run_smtp_server;
 use std::env;
+use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
 use std::process;
 use std::sync::Arc;
 
@@ -85,19 +86,21 @@ async fn main() {
         }
     };
 
-    let listen = env::var("LISTEN_IP").map_or(std::net::Ipv4Addr::LOCALHOST.into(), |s| {
-        match s.parse::<std::net::IpAddr>() {
+    let listen =
+        env::var("LISTEN_IP").map_or(Ipv4Addr::LOCALHOST.into(), |s| match s.parse::<IpAddr>() {
             Ok(ip) => ip,
             Err(e) => {
                 eprintln!("Cannot parse listen address: {e}");
                 process::exit(1);
             }
-        }
-    });
+        });
+
+    let postfix =
+        env::var("POSTFIX_HOST").map_or(Ipv4Addr::LOCALHOST.into(), |s| resolve_postfix_host(&s));
 
     if mode == "outgoing" {
         let addr = (listen, config.filtermail_smtp_port);
-        let handler = Arc::new(OutgoingBeforeQueueHandler::new(config.clone()));
+        let handler = Arc::new(OutgoingBeforeQueueHandler::new(config.clone(), postfix));
         let max_size = config.max_message_size;
         log::debug!("Outgoing SMTP server listening on {}:{}", addr.0, addr.1);
 
@@ -118,13 +121,29 @@ async fn main() {
         let addr = (listen, config.filtermail_smtp_port_incoming);
         let handler = Arc::new(
             // We want to panic here if the handler cannot be created.
-            IncomingBeforeQueueHandler::new(config.clone(), skip_dkim).unwrap(),
+            IncomingBeforeQueueHandler::new(config.clone(), skip_dkim, postfix).unwrap(),
         );
         let max_size = config.max_message_size;
         log::debug!("Incoming SMTP server listening on {}:{}", addr.0, addr.1);
 
         if let Err(e) = run_smtp_server(&addr, handler, max_size).await {
             eprintln!("Server error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn resolve_postfix_host(s: &str) -> IpAddr {
+    match (s, 0).to_socket_addrs() {
+        Ok(mut addrs) => match addrs.next() {
+            Some(addr) => addr.ip(),
+            None => {
+                eprintln!("Cannot resolve postfix host");
+                process::exit(1);
+            }
+        },
+        Err(e) => {
+            eprintln!("Cannot resolve postfix host: {e}");
             process::exit(1);
         }
     }

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -21,7 +21,7 @@ pub struct OutgoingBeforeQueueHandler {
 impl OutgoingBeforeQueueHandler {
     pub fn new(config: Config) -> Result<Self, crate::error::Error> {
         let reinject_addr =
-            crate::resolve_addr(&config.postfix_reinject_host, config.postfix_reinject_port)?;
+            crate::resolve_addr(&config.postfix_host, config.postfix_reinject_port)?;
         let quota = Quota::per_minute(config.max_user_send_per_minute)
             .allow_burst(config.max_user_send_burst_size);
         Ok(Self {

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -9,7 +9,7 @@ use crate::utils::extract_address;
 use async_trait::async_trait;
 use governor::{DefaultKeyedRateLimiter, Quota, RateLimiter};
 use mailparse::{MailHeaderMap, parse_mail};
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
 /// Handler for outgoing SMTP messages.
 pub struct OutgoingBeforeQueueHandler {
@@ -19,15 +19,16 @@ pub struct OutgoingBeforeQueueHandler {
 }
 
 impl OutgoingBeforeQueueHandler {
-    pub fn new(config: Config, postfix_host: IpAddr) -> Self {
-        let reinject_addr = SocketAddr::new(postfix_host, config.postfix_reinject_port);
+    pub fn new(config: Config) -> Result<Self, crate::error::Error> {
+        let reinject_addr =
+            crate::resolve_addr(&config.postfix_reinject_host, config.postfix_reinject_port)?;
         let quota = Quota::per_minute(config.max_user_send_per_minute)
             .allow_burst(config.max_user_send_burst_size);
-        Self {
+        Ok(Self {
             config,
             reinject_addr,
             send_rate_limiter: RateLimiter::keyed(quota),
-        }
+        })
     }
 }
 

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -9,19 +9,23 @@ use crate::utils::extract_address;
 use async_trait::async_trait;
 use governor::{DefaultKeyedRateLimiter, Quota, RateLimiter};
 use mailparse::{MailHeaderMap, parse_mail};
+use std::net::{IpAddr, SocketAddr};
 
 /// Handler for outgoing SMTP messages.
 pub struct OutgoingBeforeQueueHandler {
     config: Config,
+    reinject_addr: SocketAddr,
     send_rate_limiter: DefaultKeyedRateLimiter<String>,
 }
 
 impl OutgoingBeforeQueueHandler {
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: Config, postfix_host: IpAddr) -> Self {
+        let reinject_addr = SocketAddr::new(postfix_host, config.postfix_reinject_port);
         let quota = Quota::per_minute(config.max_user_send_per_minute)
             .allow_burst(config.max_user_send_burst_size);
         Self {
             config,
+            reinject_addr,
             send_rate_limiter: RateLimiter::keyed(quota),
         }
     }
@@ -125,7 +129,7 @@ impl SmtpHandler for OutgoingBeforeQueueHandler {
     async fn reinject_mail(&self, envelope: &Envelope) -> Result<(), String> {
         log::debug!("Re-injecting the mail that passed checks");
 
-        crate::smtp_client::send(self.config.postfix_reinject_port, envelope)
+        crate::smtp_client::send(self.reinject_addr, envelope)
             .await
             .map_err(|e| {
                 log::warn!("Failed to re-inject mail: {}", e);

--- a/src/smtp_client.rs
+++ b/src/smtp_client.rs
@@ -1,20 +1,16 @@
 use crate::smtp_server::Envelope;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufStream};
 use tokio::net::TcpSocket;
 
-const LOCALHOST: IpAddr = IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1));
-
 /// Sends an email using an SMTP server at `localhost:<smtp_port>`.
-pub async fn send(smtp_port: u16, envelope: &Envelope) -> Result<(), crate::error::Error> {
+pub async fn send(smtp_addr: SocketAddr, envelope: &Envelope) -> Result<(), crate::error::Error> {
     let socket = TcpSocket::new_v4()?;
 
     // Disable Nagle's algorithm.
     socket.set_nodelay(true)?;
 
-    let stream = socket
-        .connect(SocketAddr::new(LOCALHOST, smtp_port))
-        .await?;
+    let stream = socket.connect(smtp_addr).await?;
 
     let mut buf_stream = BufStream::new(stream);
     let mut response = String::new();

--- a/src/smtp_client.rs
+++ b/src/smtp_client.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufStream};
 use tokio::net::TcpSocket;
 
-/// Sends an email using an SMTP server at `localhost:<smtp_port>`.
+/// Sends an email using an SMTP server at `smtp_addr`.
 pub async fn send(smtp_addr: SocketAddr, envelope: &Envelope) -> Result<(), crate::error::Error> {
     let socket = TcpSocket::new_v4()?;
 

--- a/src/smtp_server.rs
+++ b/src/smtp_server.rs
@@ -43,7 +43,7 @@ pub trait SmtpHandler: Send + Sync {
 
 /// Runs the SMTP server on the specified address with the given handler and maximum message size.
 pub async fn run_smtp_server<H>(
-    addr: &str,
+    addr: &impl tokio::net::ToSocketAddrs,
     handler: Arc<H>,
     max_size: usize,
 ) -> Result<(), Box<dyn std::error::Error>>


### PR DESCRIPTION
Currently, filtermail always listens on localhost and assumes that postfix is always on localhost. This can be different in some setups, e.g. when filtermail and postfix are in separate docker containers (sharing the same docker network).

This PR adds configurable listen IP and postfix host via ~~`LISTEN_IP` and `POSTFIX_HOST` env vars~~ `filtermail_host` and `postfix_host` chatmail.ini config fields.
Postfix host is resolved with `ToSocketAddrs` so we can use an internal docker container host (e.g. service name when run in a docker compose) instead of finding out its IP address.

I'm absolutely okay with maintaining a [soft-fork](https://git.dc09.xyz/chatmail/filtermail) for my "chatmail in docker" project (work in progress), but i thought it could be useful for the upstream as well. Feel free to provide any suggestions regarding the code.