### PR TITLE
feat(resolver): Enable DNSSEC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
+ "bitflags",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
@@ -593,7 +603,9 @@ dependencies = [
  "once_cell",
  "rand 0.9.2",
  "ring",
+ "rustls-pki-types",
  "thiserror",
+ "time",
  "tinyvec",
  "tokio",
  "tracing",
@@ -920,6 +932,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1077,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1313,6 +1337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1562,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.29"
 env_logger = "0.11.9"
 governor = "0.10.4"
 viadkim = { version = "0.2.0" }
-hickory-resolver = "0.25.2"
+hickory-resolver = { version = "0.25.2", features = ["dnssec-ring"] }
 lru = "0.16.3"
 parking_lot = "0.12.5"
 

--- a/src/dkim_verifier.rs
+++ b/src/dkim_verifier.rs
@@ -40,7 +40,17 @@ impl CachedResolver {
     /// Creates a new [`CachedResolver`].
     pub fn new() -> Result<Self, crate::error::Error> {
         // Use resolv.conf
-        let dns_resolver = TokioResolver::builder(TokioConnectionProvider::default())?.build();
+        let dns_resolver = {
+            let mut builder = TokioResolver::builder(TokioConnectionProvider::default())?;
+            // https://github.com/hickory-dns/hickory-dns/issues/3519
+            builder.options_mut().validate = true;
+            builder.build()
+        };
+
+        assert!(
+            dns_resolver.options().validate,
+            "incorrect resolver config: DNSSEC disabled; exiting"
+        );
 
         let cache = Arc::new(parking_lot::Mutex::new(LruCache::new(LRU_CACHE_CAPACITY)));
 


### PR DESCRIPTION
From hickory-resolver docs:
> To enable DNSSEC, enable the dnssec-ring feature.

Related: https://github.com/chatmail/relay/issues/877
Closes: https://github.com/chatmail/filtermail/issues/93