### PR TITLE
feat: exit on ctrl+c

### DIFF
--- a/src/smtp_server.rs
+++ b/src/smtp_server.rs
@@ -51,6 +51,20 @@ where
     H: SmtpHandler + 'static,
 {
     let listener = TcpListener::bind(addr).await?;
+    tokio::select! {
+        r = run_loop(listener, handler, max_size) => r,
+        _ = tokio::signal::ctrl_c() => Ok(()),
+    }
+}
+
+async fn run_loop<H>(
+    listener: TcpListener,
+    handler: Arc<H>,
+    max_size: usize,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    H: SmtpHandler + 'static,
+{
     // message for backward compatibility with chatmaild tests.
     log::info!("entering serving loop");
 


### PR DESCRIPTION
I found a weird bug and idk how to reproduce it in a more common environment than containerization.

When filtermail binary is started inside a Docker container, the only way to terminate it is to send SIGKILL, all signals are ignored for some reason. However, if you launch filtermail from an *interactive* shell, INT and TERM work perfectly (both with Ctrl+C and pkill).

Another workaround is:
```shell
/filtermail /chatmail.ini outgoing &
pid=$!
trap "kill -INT $pid" INT
wait $pid
```
This works too, for some reason.

All in all, it's better to explicitly handle signals. I also don't know why Ctrl+C worked in filtermail, as I can see there was no handler and Tokio doesn't provide one by default (?)