### PR TITLE
fix: Implement missing "implicit MX" rule

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -62,14 +62,23 @@ impl TransportHandler {
 
                 match dns_resolver.mx_lookup(query).await {
                     Ok(mx_records) => {
-                        let mut hosts: Vec<(u16, String)> = mx_records
-                            .iter()
-                            .map(|mx| {
-                                let host =
-                                    mx.exchange().to_string().trim_end_matches('.').to_string();
-                                (mx.preference(), host)
-                            })
-                            .collect();
+                        let mut hosts: Vec<(u16, String)> = Vec::new();
+                        for mx in mx_records {
+                            // Null MX / RFC7505
+                            if mx.exchange().is_root() {
+                                // From RFC7505 section 3:
+                                // > A domain that advertises a null MX MUST NOT
+                                // > advertise any other MX RR.
+                                // We assume this is the only record and exit early.
+                                return Err(
+                                    "556 5.1.10 Permanent failure: Recipient address has null MX"
+                                        .to_string(),
+                                );
+                            }
+
+                            let host = mx.exchange().to_string().trim_end_matches('.').to_string();
+                            hosts.push((mx.preference(), host))
+                        }
                         hosts.sort();
                         hosts
                     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -59,25 +59,33 @@ impl TransportHandler {
                     allow_invalid_cert = true;
                 }
                 let query = format!("{mx_domain}.");
-                let mx_records = dns_resolver.mx_lookup(query).await.map_err(|e| {
-                    if e.is_no_records_found() {
-                        format!("512 No MX records for {mx_domain}")
-                    } else if e.is_nx_domain() {
-                        format!("512 Domain {mx_domain} does not exist")
-                    } else {
-                        format!("421 DNS resolution failed for {mx_domain}")
-                    }
-                })?;
 
-                let mut hosts: Vec<(u16, String)> = mx_records
-                    .iter()
-                    .map(|mx| {
-                        let host = mx.exchange().to_string().trim_end_matches('.').to_string();
-                        (mx.preference(), host)
-                    })
-                    .collect();
-                hosts.sort();
-                hosts
+                match dns_resolver.mx_lookup(query).await {
+                    Ok(mx_records) => {
+                        let mut hosts: Vec<(u16, String)> = mx_records
+                            .iter()
+                            .map(|mx| {
+                                let host =
+                                    mx.exchange().to_string().trim_end_matches('.').to_string();
+                                (mx.preference(), host)
+                            })
+                            .collect();
+                        hosts.sort();
+                        hosts
+                    }
+                    Err(e) => {
+                        if e.is_no_records_found() {
+                            // "implicit MX" as described by section 5.1 of RFC5321
+                            // https://datatracker.ietf.org/doc/html/rfc5321#section-5.1
+                            log::debug!("No MX record found, using implicit MX: {mx_domain}");
+                            vec![(0, mx_domain)]
+                        } else if e.is_nx_domain() {
+                            return Err(format!("512 Domain {mx_domain} does not exist"));
+                        } else {
+                            return Err(format!("421 DNS resolution failed for {mx_domain}"));
+                        }
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
Implements "implicit MX" as described by
https://datatracker.ietf.org/doc/html/rfc5321#section-5.1

Fixes: #126