### PR TITLE
perf(smtp-client): Use FQDN to reduce number of DNS queries

### DIFF
--- a/src/smtp_client.rs
+++ b/src/smtp_client.rs
@@ -139,7 +139,7 @@ async fn to_socket_addrs(
     if let Ok(ip) = address.parse() {
         Ok(vec![std::net::SocketAddr::new(ip, port)])
     } else {
-        let lookup = dns_resolver.lookup_ip(address).await?;
+        let lookup = dns_resolver.lookup_ip(format!("{address}.")).await?;
         Ok(lookup
             .iter()
             .map(|ip| std::net::SocketAddr::new(ip, port))


### PR DESCRIPTION
From `hickory-resolver` docs:
> FQDN, which ends in a final `.`, e.g. `www.example.com.`,
> will only issue one query.
> Anything else will always incur the cost of querying
> the `ResolverConfig::domain` and `ResolverConfig::search`.