### PR TITLE
fix: advertise 8BITMIME to prevent conversion after DKIM signing

### DIFF
--- a/src/smtp_server.rs
+++ b/src/smtp_server.rs
@@ -121,7 +121,7 @@ where
             || cmd.to_uppercase().starts_with("LHLO")
         {
             writer
-                .write_all(b"250-filtermail\r\n250-XFORWARD ADDR\r\n250 OK\r\n")
+                .write_all(b"250-filtermail\r\n250-XFORWARD ADDR\r\n250-8BITMIME\r\n250 OK\r\n")
                 .await?;
             writer.flush().await?;
         } else if cmd.to_uppercase().starts_with("MAIL FROM:<>") {


### PR DESCRIPTION
for bounces postfix sets Content-Transfer-Encoding: 8bit which causes a quoted-printable conversion when filtermail SMTP does not offer 8BITMIME, which in turn breaks DKIM verification at recipient sites.
