### PR TITLE
feat(transport): Destination worker pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +576,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "insta",
  "log",
  "lru",
  "mailparse",
@@ -567,6 +585,7 @@ dependencies = [
  "retainer",
  "rstest",
  "serde",
+ "serial_test",
  "serini",
  "testresult",
  "thiserror",
@@ -630,6 +649,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1146,6 +1176,18 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -2003,6 +2045,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serini"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2131,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -2182,6 +2255,19 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "testresult"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ hyper-rustls = { version = "0.27.9", default-features = false, features = [
 [dev-dependencies]
 rstest = "0.26.1"
 testresult = "0.4.1"
+insta = "1.48.0"
+serial_test = "3.5.0"
 
 [profile.release]
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -110,9 +110,19 @@ As opposed to incoming/outgoing, it accepts connections from postfix over LMTP i
 to allow returning per-recipient status back to postfix.
 Received message is split per-domain and sent to recipients' MX servers over HTTP and SMTP,
 enforcing TLS.
+
 As opposed to postfix, IPv4 and IPv6 connections are tried in parallel and first successful connection is used.
 HTTP delivery channel is preferred,
 and SMTP is used only if HTTP delivery fails.
+
+Filtermail spawns a separate worker for each destination
+(distinguished by [domain][RFC5322_3_4_1] part of the recipient's [addr-spec][RFC5322_3_4_1],
+NOT the actual MX server).
+Only messages to the same destination are guaranteed to be sent in-order
+(if not deferred and sent over the same LMTP connection);
+messages to different destinations are NOT synchronized.
+
+[RFC5322_3_4_1]: https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1
 
 ## Configuration
 

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -1,4 +1,4 @@
-use crate::smtp_server::{Envelope, SmtpHandler};
+use crate::smtp_server::{SmtpHandler, Transaction};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
@@ -93,6 +93,8 @@ impl<H: SmtpHandler + 'static> Service<Request<Incoming>> for MxDelivService<H> 
                 )?);
             }
 
+            let mut transaction = Transaction::default();
+
             let mail_from = req
                 .headers()
                 .get(crate::transport::HEADER_MAIL_FROM)
@@ -100,22 +102,35 @@ impl<H: SmtpHandler + 'static> Service<Request<Incoming>> for MxDelivService<H> 
                 .unwrap_or("")
                 .to_string();
 
-            match handler.handle_mail(&mail_from) {
-                Ok(_) => {}
-                Err(e) => {
-                    return Ok(Response::builder()
-                        .status(400)
-                        .body(Full::new(Bytes::from(e)).boxed())?);
-                }
-            };
+            if let Err(e) = handler.handle_mail_from(&mail_from) {
+                return Ok(Response::builder()
+                    .status(400)
+                    .body(Full::new(Bytes::from(e)).boxed())?);
+            }
+            transaction.envelope.mail_from = mail_from;
 
-            let rcpt_to = req
+            let rcpt_to: Vec<String> = req
                 .headers()
                 .get_all(crate::transport::HEADER_RCPT_TO)
                 .iter()
                 .filter_map(|v| v.to_str().ok())
                 .map(ToString::to_string)
                 .collect();
+
+            for r in &rcpt_to {
+                if let Err(e) = handler.handle_rcpt_to(r, &mut transaction) {
+                    return Ok(Response::builder()
+                        .status(400)
+                        .body(Full::new(Bytes::from(e)).boxed())?);
+                }
+            }
+            transaction.envelope.rcpt_to = rcpt_to;
+
+            if let Err(e) = handler.handle_data_start(&transaction) {
+                return Ok(Response::builder()
+                    .status(400)
+                    .body(Full::new(Bytes::from(e)).boxed())?);
+            }
 
             let body_limited = http_body_util::Limited::new(req.into_body(), max_size);
             let body_bytes = match body_limited.collect().await {
@@ -127,24 +142,19 @@ impl<H: SmtpHandler + 'static> Service<Request<Incoming>> for MxDelivService<H> 
                 }
             };
 
-            let mut envelope = Envelope {
-                origin_ip: "".to_string(),
-                mail_from,
-                rcpt_to,
-                data: body_bytes.to_vec(),
-            };
+            transaction.envelope.data = body_bytes.to_vec();
 
-            log::debug!("(HTTP) MAIL FROM:<{}>", envelope.mail_from);
-            for rcpt in &envelope.rcpt_to {
+            log::debug!("(HTTP) MAIL FROM:<{}>", transaction.envelope.mail_from);
+            for rcpt in &transaction.envelope.rcpt_to {
                 log::debug!("(HTTP) RCPT TO:<{}>", rcpt);
             }
 
             log::trace!(
                 "(HTTP) DATA:\n{:?}",
-                String::from_utf8_lossy(&envelope.data)
+                String::from_utf8_lossy(&transaction.envelope.data)
             );
 
-            match handler.handle_data(&mut envelope).await {
+            match handler.handle_data_dot(&mut transaction).await {
                 Ok(response) => Ok(Response::builder()
                     .status(200)
                     .body(Full::new(Bytes::from(response)).boxed())?),

--- a/src/inbound.rs
+++ b/src/inbound.rs
@@ -1,12 +1,12 @@
 //! Module for handling incoming SMTP messages.
 
-use crate::ENCRYPTION_NEEDED_523;
 use crate::config::Config;
 use crate::dkim_verifier::DkimVerifier;
 use crate::message::{check_encrypted, is_securejoin};
 use crate::smtp_client::SmtpConnectionPool;
+use crate::smtp_responses::ENCRYPTION_NEEDED_523;
 pub use crate::smtp_server::Envelope;
-use crate::smtp_server::SmtpHandler;
+use crate::smtp_server::{SmtpHandler, Transaction};
 use crate::utils::{AddressDomain, build_resolver, extract_address, log_eml};
 use async_trait::async_trait;
 use hickory_resolver::TokioResolver;
@@ -69,12 +69,10 @@ impl IncomingBeforeQueueHandler {
 
 #[async_trait]
 impl SmtpHandler for IncomingBeforeQueueHandler {
-    fn handle_mail(&self, _address: &str) -> Result<(), String> {
-        Ok(())
-    }
+    type State = ();
 
-    async fn check_data(&self, envelope: &mut Envelope) -> Result<(), String> {
-        let message = match parse_mail(&envelope.data) {
+    async fn check_data(&self, transaction: &mut Transaction<Self::State>) -> Result<(), String> {
+        let message = match parse_mail(&transaction.envelope.data) {
             Ok(m) => m,
             Err(e) => return Err(format!("500 Failed to parse message: {}", e)),
         };
@@ -92,16 +90,21 @@ impl SmtpHandler for IncomingBeforeQueueHandler {
 
         log::debug!("Processing DATA message from {from_addr}");
 
-        if !envelope.mail_from.eq_ignore_ascii_case(&from_addr) {
+        if !transaction
+            .envelope
+            .mail_from
+            .eq_ignore_ascii_case(&from_addr)
+        {
             // If the MAIL FROM doesn't match the From header, we do not reject the mail,
             // as this can be caused by e.g. SRS forwarding.
             // Instead, we reset the envelope address, so it is reinjected as
             // `MAIL FROM:<>` to prevent sending a bounce message.
             // <https://github.com/chatmail/filtermail/issues/67>
-            envelope.mail_from = String::new();
+            transaction.envelope.mail_from = String::new();
         }
 
-        envelope.rcpt_to = envelope
+        transaction.envelope.rcpt_to = transaction
+            .envelope
             .rcpt_to
             .iter()
             .filter(|s| {
@@ -121,7 +124,7 @@ impl SmtpHandler for IncomingBeforeQueueHandler {
         // Allow encrypted or securejoin messages
         if mail_encrypted || is_securejoin(&message) {
             log::info!("Incoming: Filtering encrypted mail.");
-            return self.verify_origin(envelope, &from_addr).await;
+            return self.verify_origin(&transaction.envelope, &from_addr).await;
         }
 
         log::info!("Incoming: Filtering unencrypted mail.");
@@ -132,26 +135,26 @@ impl SmtpHandler for IncomingBeforeQueueHandler {
             && from_addr.to_lowercase().starts_with("mailer-daemon@")
             && message.ctype.mimetype == "multipart/report"
         {
-            return self.verify_origin(envelope, &from_addr).await;
+            return self.verify_origin(&transaction.envelope, &from_addr).await;
         }
 
-        for recipient in &envelope.rcpt_to {
+        for recipient in &transaction.envelope.rcpt_to {
             if !self.config.is_cleartext_ok(recipient) {
                 log::warn!("Rejected unencrypted mail from: {from_addr}");
                 return Err(ENCRYPTION_NEEDED_523.to_string());
             }
         }
 
-        self.verify_origin(envelope, &from_addr).await
+        self.verify_origin(&transaction.envelope, &from_addr).await
     }
 
-    async fn reinject_mail(&self, envelope: &Envelope) -> Result<(), String> {
+    async fn reinject_mail(&self, transaction: &Transaction<Self::State>) -> Result<(), String> {
         log::debug!("Re-injecting the mail that passed checks");
         let hostname = format!("[{}]", self.config.filtermail_host);
         crate::smtp_client::send(
             &self.config.postfix_host,
             self.config.postfix_reinject_port_incoming,
-            envelope,
+            &transaction.envelope,
             &hostname,
             None,
             self.dns_resolver.clone(),
@@ -189,12 +192,14 @@ mod tests {
         config: Config,
     ) -> TestResult {
         let handler = IncomingBeforeQueueHandler::new(config, false)?;
-        let mut envelope = Envelope {
-            mail_from: address.to_string(),
-            origin_ip: "".to_string(), // Currently shouldn't be relevant.
-            data: eml.to_vec(),
-            rcpt_to: vec!["does.not.matter@example.org".to_string()],
+        let mut transaction = Transaction {
+            envelope: Envelope {
+                mail_from: address.to_string(),
+                data: eml.to_vec(),
+                rcpt_to: vec!["does.not.matter@example.org".to_string()],
+            },
+            ..Default::default()
         };
-        Ok(handler.check_data(&mut envelope).await?)
+        Ok(handler.check_data(&mut transaction).await?)
     }
 }

--- a/src/inbound.rs
+++ b/src/inbound.rs
@@ -7,6 +7,7 @@ use crate::smtp_client::SmtpConnectionPool;
 use crate::smtp_responses::ENCRYPTION_NEEDED_523;
 pub use crate::smtp_server::Envelope;
 use crate::smtp_server::{SmtpHandler, Transaction};
+use crate::tcp::{TcpConnect, TcpStreamTrait};
 use crate::utils::{AddressDomain, build_resolver, extract_address, log_eml};
 use async_trait::async_trait;
 use hickory_resolver::TokioResolver;
@@ -15,15 +16,19 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 /// Handler for incoming SMTP messages.
-pub struct IncomingBeforeQueueHandler {
+pub struct IncomingBeforeQueueHandler<S: TcpConnect> {
     config: Config,
     dns_resolver: Arc<TokioResolver>,
     dkim_verifier: DkimVerifier,
     skip_dkim: bool,
-    smtp_connection_pool: Arc<SmtpConnectionPool>,
+    smtp_connection_pool: Arc<SmtpConnectionPool<S>>,
 }
 
-impl IncomingBeforeQueueHandler {
+impl<S> IncomingBeforeQueueHandler<S>
+where
+    S: TcpStreamTrait + TcpConnect,
+    S::ConnectionContext: Default,
+{
     pub fn new(config: Config, skip_dkim: bool) -> Result<Self, crate::error::Error> {
         let dns_resolver = Arc::new(build_resolver()?);
         Ok(Self {
@@ -31,7 +36,7 @@ impl IncomingBeforeQueueHandler {
             dns_resolver: dns_resolver.clone(),
             dkim_verifier: DkimVerifier::new(dns_resolver),
             skip_dkim,
-            smtp_connection_pool: SmtpConnectionPool::new(),
+            smtp_connection_pool: SmtpConnectionPool::new(Default::default()),
         })
     }
 
@@ -68,7 +73,11 @@ impl IncomingBeforeQueueHandler {
 }
 
 #[async_trait]
-impl SmtpHandler for IncomingBeforeQueueHandler {
+impl<S> SmtpHandler for IncomingBeforeQueueHandler<S>
+where
+    S: TcpStreamTrait + TcpConnect,
+    S::ConnectionContext: Default,
+{
     type State = ();
 
     async fn check_data(&self, transaction: &mut Transaction<Self::State>) -> Result<(), String> {
@@ -151,12 +160,16 @@ impl SmtpHandler for IncomingBeforeQueueHandler {
     async fn reinject_mail(&self, transaction: &Transaction<Self::State>) -> Result<(), String> {
         log::debug!("Re-injecting the mail that passed checks");
         let hostname = format!("[{}]", self.config.filtermail_host);
+        let client_config = crate::smtp_client::ClientConfig {
+            client_hostname: &hostname,
+            tls_config: None,
+            lmtp: false,
+        };
         crate::smtp_client::send(
             &self.config.postfix_host,
             self.config.postfix_reinject_port_incoming,
             &transaction.envelope,
-            &hostname,
-            None,
+            client_config,
             self.dns_resolver.clone(),
             self.smtp_connection_pool.clone(),
         )
@@ -175,6 +188,7 @@ mod tests {
     use super::*;
     use rstest::{fixture, rstest};
     use testresult::TestResult;
+    use tokio::net::TcpStream;
 
     #[fixture]
     fn config() -> Config {
@@ -191,7 +205,7 @@ mod tests {
         #[case] address: &str,
         config: Config,
     ) -> TestResult {
-        let handler = IncomingBeforeQueueHandler::new(config, false)?;
+        let handler = IncomingBeforeQueueHandler::<TcpStream>::new(config, false)?;
         let mut transaction = Transaction {
             envelope: Envelope {
                 mail_from: address.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ pub(crate) mod outbound;
 pub(crate) mod smtp_client;
 mod smtp_responses;
 pub(crate) mod smtp_server;
+mod tcp;
 mod tls;
 mod transport;
 pub(crate) mod utils;
@@ -50,6 +51,7 @@ use std::env;
 use std::process;
 use std::str::FromStr;
 use std::sync::Arc;
+use tokio::net::TcpStream;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum Mode {
@@ -120,7 +122,9 @@ async fn main() -> Result<(), error::Error> {
     match mode {
         Mode::Outgoing => {
             let addr = (config.filtermail_host, config.filtermail_smtp_port);
-            let handler = Arc::new(OutgoingBeforeQueueHandler::new(config.clone())?);
+            let handler = Arc::new(OutgoingBeforeQueueHandler::<TcpStream>::new(
+                config.clone(),
+            )?);
             let max_size = config.max_message_size;
             log::debug!("Outgoing SMTP server listening on {}:{}", addr.0, addr.1);
 
@@ -139,7 +143,10 @@ async fn main() -> Result<(), error::Error> {
                 log::warn!("DKIM verification DISABLED! This should not be used in production.");
             }
 
-            let handler = Arc::new(IncomingBeforeQueueHandler::new(config.clone(), skip_dkim)?);
+            let handler = Arc::new(IncomingBeforeQueueHandler::<TcpStream>::new(
+                config.clone(),
+                skip_dkim,
+            )?);
             let max_size = config.max_message_size;
 
             let mut server_set = tokio::task::JoinSet::new();
@@ -177,7 +184,7 @@ async fn main() -> Result<(), error::Error> {
                 config.filtermail_host,
                 config.filtermail_lmtp_port_transport,
             );
-            let handler = Arc::new(TransportHandler::new(config.clone())?);
+            let handler = Arc::new(TransportHandler::<TcpStream>::new(config.clone())?);
             let max_size = config.max_message_size;
             log::debug!("Transport SMTP server listening on {}:{}", addr.0, addr.1);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ pub(crate) mod message;
 pub(crate) mod openpgp;
 pub(crate) mod outbound;
 pub(crate) mod smtp_client;
+mod smtp_responses;
 pub(crate) mod smtp_server;
 mod tls;
 mod transport;
@@ -49,8 +50,6 @@ use std::env;
 use std::process;
 use std::str::FromStr;
 use std::sync::Arc;
-
-const ENCRYPTION_NEEDED_523: &str = "523 Encryption Needed: Invalid Unencrypted Mail";
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum Mode {

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -6,6 +6,7 @@ use crate::smtp_client::SmtpConnectionPool;
 use crate::smtp_responses::ENCRYPTION_NEEDED_523;
 use crate::smtp_responses::OK_250;
 use crate::smtp_server::{SmtpHandler, Transaction};
+use crate::tcp::{TcpConnect, TcpStreamTrait};
 use crate::utils::{build_resolver, extract_address};
 use async_trait::async_trait;
 use governor::clock::MonotonicClock;
@@ -16,7 +17,7 @@ use mailparse::{MailHeaderMap, parse_mail};
 use std::sync::Arc;
 
 /// Handler for outgoing SMTP messages.
-pub struct OutgoingBeforeQueueHandler {
+pub struct OutgoingBeforeQueueHandler<S: TcpConnect> {
     config: Config,
     dns_resolver: Arc<TokioResolver>,
 
@@ -33,10 +34,14 @@ pub struct OutgoingBeforeQueueHandler {
         MonotonicClock,
         NoOpMiddleware<std::time::Instant>,
     >,
-    smtp_connection_pool: Arc<SmtpConnectionPool>,
+    smtp_connection_pool: Arc<SmtpConnectionPool<S>>,
 }
 
-impl OutgoingBeforeQueueHandler {
+impl<S> OutgoingBeforeQueueHandler<S>
+where
+    S: TcpStreamTrait + TcpConnect,
+    S::ConnectionContext: Default,
+{
     pub fn new(config: Config) -> Result<Self, crate::error::Error> {
         let quota = Quota::per_minute(config.max_user_send_per_minute)
             .allow_burst(config.max_user_send_burst_size);
@@ -46,13 +51,16 @@ impl OutgoingBeforeQueueHandler {
             config,
             dns_resolver,
             send_rate_limiter,
-            smtp_connection_pool: SmtpConnectionPool::new(),
+            smtp_connection_pool: SmtpConnectionPool::new(Default::default()),
         })
     }
 }
 
 #[async_trait]
-impl SmtpHandler for OutgoingBeforeQueueHandler {
+impl<S> SmtpHandler for OutgoingBeforeQueueHandler<S>
+where
+    S: TcpStreamTrait + TcpConnect,
+{
     type State = ();
 
     fn handle_mail_from(&self, address: &str) -> Result<(), String> {
@@ -161,12 +169,16 @@ impl SmtpHandler for OutgoingBeforeQueueHandler {
     async fn reinject_mail(&self, transaction: &Transaction<Self::State>) -> Result<(), String> {
         log::debug!("Re-injecting the mail that passed checks");
         let hostname = format!("[{}]", self.config.filtermail_host);
+        let client_config = crate::smtp_client::ClientConfig {
+            client_hostname: &hostname,
+            tls_config: None,
+            lmtp: false,
+        };
         crate::smtp_client::send(
             &self.config.postfix_host,
             self.config.postfix_reinject_port,
             &transaction.envelope,
-            &hostname,
-            None,
+            client_config,
             self.dns_resolver.clone(),
             self.smtp_connection_pool.clone(),
         )

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -1,11 +1,11 @@
 //! Module for handling outgoing SMTP messages.
 
-use crate::ENCRYPTION_NEEDED_523;
 use crate::config::Config;
 use crate::message::{check_encrypted, is_securejoin};
 use crate::smtp_client::SmtpConnectionPool;
-pub use crate::smtp_server::Envelope;
-use crate::smtp_server::SmtpHandler;
+use crate::smtp_responses::ENCRYPTION_NEEDED_523;
+use crate::smtp_responses::OK_250;
+use crate::smtp_server::{SmtpHandler, Transaction};
 use crate::utils::{build_resolver, extract_address};
 use async_trait::async_trait;
 use governor::clock::MonotonicClock;
@@ -53,7 +53,9 @@ impl OutgoingBeforeQueueHandler {
 
 #[async_trait]
 impl SmtpHandler for OutgoingBeforeQueueHandler {
-    fn handle_mail(&self, address: &str) -> Result<(), String> {
+    type State = ();
+
+    fn handle_mail_from(&self, address: &str) -> Result<(), String> {
         log::debug!("handle_MAIL from {address}");
 
         let parts: Vec<&str> = address.split('@').collect();
@@ -79,8 +81,8 @@ impl SmtpHandler for OutgoingBeforeQueueHandler {
         Ok(())
     }
 
-    async fn check_data(&self, envelope: &mut Envelope) -> Result<(), String> {
-        let message = match parse_mail(&envelope.data) {
+    async fn check_data(&self, transaction: &mut Transaction<Self::State>) -> Result<(), String> {
+        let message = match parse_mail(&transaction.envelope.data) {
             Ok(m) => m,
             Err(e) => return Err(format!("500 Failed to parse message: {}", e)),
         };
@@ -97,7 +99,8 @@ impl SmtpHandler for OutgoingBeforeQueueHandler {
         let from_addr = extract_address(&from_header)
             .ok_or(format!("500 Invalid FROM header: {from_header}"))?;
 
-        envelope.rcpt_to = envelope
+        transaction.envelope.rcpt_to = transaction
+            .envelope
             .rcpt_to
             .iter()
             .filter(|s| {
@@ -113,12 +116,19 @@ impl SmtpHandler for OutgoingBeforeQueueHandler {
         // MAIL FROM is our source of truth for outbound messages,
         // as this address is checked by postfix against the username before sending it
         // to filtermail.
-        log::debug!("Processing DATA message from {}", envelope.mail_from);
+        log::debug!(
+            "Processing DATA message from {}",
+            transaction.envelope.mail_from
+        );
 
-        if !envelope.mail_from.eq_ignore_ascii_case(&from_addr) {
+        if !transaction
+            .envelope
+            .mail_from
+            .eq_ignore_ascii_case(&from_addr)
+        {
             return Err(format!(
                 "500 Invalid FROM <{}> for <{}>",
-                from_addr, envelope.mail_from
+                from_addr, transaction.envelope.mail_from
             ));
         }
 
@@ -131,8 +141,8 @@ impl SmtpHandler for OutgoingBeforeQueueHandler {
         log::info!("Outgoing: Filtering unencrypted mail.");
 
         // Allow self-sent Autocrypt Setup Message
-        if envelope.rcpt_to.len() == 1
-            && let Some(rcpt_to) = envelope.rcpt_to.first()
+        if transaction.envelope.rcpt_to.len() == 1
+            && let Some(rcpt_to) = transaction.envelope.rcpt_to.first()
             && *rcpt_to == from_addr
         {
             let subject = message
@@ -148,13 +158,13 @@ impl SmtpHandler for OutgoingBeforeQueueHandler {
         Err(ENCRYPTION_NEEDED_523.to_string())
     }
 
-    async fn reinject_mail(&self, envelope: &Envelope) -> Result<(), String> {
+    async fn reinject_mail(&self, transaction: &Transaction<Self::State>) -> Result<(), String> {
         log::debug!("Re-injecting the mail that passed checks");
         let hostname = format!("[{}]", self.config.filtermail_host);
         crate::smtp_client::send(
             &self.config.postfix_host,
             self.config.postfix_reinject_port,
-            envelope,
+            &transaction.envelope,
             &hostname,
             None,
             self.dns_resolver.clone(),
@@ -169,21 +179,27 @@ impl SmtpHandler for OutgoingBeforeQueueHandler {
         Ok(())
     }
 
-    async fn handle_data(&self, envelope: &mut Envelope) -> Result<String, String> {
+    async fn handle_data_dot(
+        &self,
+        transaction: &mut Transaction<Self::State>,
+    ) -> Result<String, String> {
         log::debug!("handle_DATA before-queue");
-        self.check_data(envelope).await?;
-        if self.config.is_disabled(&envelope.mail_from) {
-            log::warn!("Dropping mail; Sender {} is disabled.", envelope.mail_from);
-            return Ok("250 OK".to_string());
+        self.check_data(transaction).await?;
+        if self.config.is_disabled(&transaction.envelope.mail_from) {
+            log::warn!(
+                "Dropping mail; Sender {} is disabled.",
+                transaction.envelope.mail_from
+            );
+            return Ok(OK_250.to_string());
         }
-        if envelope.rcpt_to.is_empty() {
+        if transaction.envelope.rcpt_to.is_empty() {
             log::warn!("Dropping mail; All recipients disabled.");
-            return Ok("250 OK".to_string());
+            return Ok(OK_250.to_string());
         }
-        self.reinject_mail(envelope).await.map_err(|e| {
+        self.reinject_mail(transaction).await.map_err(|e| {
             log::warn!("Failed to reinject mail: {e}");
             e
         })?;
-        Ok("250 OK".to_string())
+        Ok(OK_250.to_string())
     }
 }

--- a/src/smtp_client.rs
+++ b/src/smtp_client.rs
@@ -1,4 +1,5 @@
 use crate::smtp_server::Envelope;
+use crate::tcp::{TcpConnect, TcpStreamTrait};
 use hickory_resolver::TokioResolver;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -6,14 +7,13 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufStream};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::net::TcpStream;
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_io_timeout::TimeoutStream;
 use tokio_rustls::rustls::client::ClientSessionMemoryCache;
 
 /// Wraps SMTP connection, contains stream and ESMTP support information.
-pub struct SmtpConnection {
-    pub stream: BufStream<SmtpStream>,
+pub struct SmtpConnection<S> {
+    pub stream: BufStream<SmtpStream<S>>,
     pub pipelining: bool,
 }
 
@@ -22,14 +22,21 @@ pub struct SmtpConnection {
 /// Connections are cached for up to 100 seconds of idle time.
 ///
 /// Only a single connection is cached per address/port pair.
-pub struct SmtpConnectionPool {
-    pool: Arc<retainer::Cache<(String, u16), SmtpConnection>>,
+pub struct SmtpConnectionPool<S>
+where
+    S: TcpStreamTrait + TcpConnect,
+{
+    pool: Arc<retainer::Cache<(String, u16), SmtpConnection<S>>>,
     monitor_handle: JoinHandle<()>,
+    context: S::ConnectionContext,
 }
 
-impl SmtpConnectionPool {
+impl<S> SmtpConnectionPool<S>
+where
+    S: TcpStreamTrait + TcpConnect,
+{
     /// Creates a new connection pool and starts the cache monitoring task.
-    pub fn new() -> Arc<Self> {
+    pub fn new(context: S::ConnectionContext) -> Arc<Self> {
         let pool = Arc::new(retainer::Cache::new());
         let pool_clone = pool.clone();
 
@@ -39,16 +46,17 @@ impl SmtpConnectionPool {
         Arc::new(Self {
             pool,
             monitor_handle,
+            context,
         })
     }
 
     /// Takes a connection from the pool for the given address and port, if available.
-    pub async fn take(&self, address: &str, port: u16) -> Option<SmtpConnection> {
+    pub async fn take(&self, address: &str, port: u16) -> Option<SmtpConnection<S>> {
         self.pool.remove(&(address.to_string(), port)).await
     }
 
     /// Puts a connection into the pool for the given address and port, with a 100s timeout.
-    pub async fn put(&self, address: &str, port: u16, connection: SmtpConnection) {
+    pub async fn put(&self, address: &str, port: u16, connection: SmtpConnection<S>) {
         // similarly to postfix default -> 100s max idle time.
         self.pool
             .insert(
@@ -60,25 +68,25 @@ impl SmtpConnectionPool {
     }
 }
 
-impl Drop for SmtpConnectionPool {
+impl<S: TcpConnect> Drop for SmtpConnectionPool<S> {
     fn drop(&mut self) {
         self.monitor_handle.abort();
     }
 }
 
-/// A [`TcpStream`] used for SMTP communication.
+/// A [`TcpStream`] wrapper used for SMTP communication.
 #[expect(clippy::large_enum_variant)]
-pub enum SmtpStream {
+pub enum SmtpStream<S> {
     /// A plain TCP stream.
-    Plain(Pin<Box<TimeoutStream<TcpStream>>>),
+    Plain(Pin<Box<TimeoutStream<S>>>),
     /// A TLS-encrypted stream.
-    Tls(tokio_rustls::TlsStream<Pin<Box<TimeoutStream<TcpStream>>>>),
+    Tls(tokio_rustls::TlsStream<Pin<Box<TimeoutStream<S>>>>),
 }
 
-impl SmtpStream {
+impl<S: TcpStreamTrait> SmtpStream<S> {
     /// Creates a new plain SMTP stream from a raw TCP stream,
     /// with read and write timeouts set to 60 seconds.
-    fn plain(stream: TcpStream) -> Self {
+    fn plain(stream: S) -> Self {
         let mut timeout_stream = TimeoutStream::new(stream);
         timeout_stream.set_write_timeout(Some(Duration::from_secs(60)));
         timeout_stream.set_read_timeout(Some(Duration::from_secs(60)));
@@ -127,7 +135,7 @@ pub struct TlsConfig {
     pub(crate) session_cache: Arc<ClientSessionMemoryCache>,
 }
 
-impl AsyncWrite for SmtpStream {
+impl<S: TcpStreamTrait> AsyncWrite for SmtpStream<S> {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -154,7 +162,7 @@ impl AsyncWrite for SmtpStream {
     }
 }
 
-impl AsyncRead for SmtpStream {
+impl<S: TcpStreamTrait> AsyncRead for SmtpStream<S> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -189,25 +197,31 @@ async fn to_socket_addrs(
 }
 
 /// Establishes a TCP connection to the given address and port, trying all resolved IPs in parallel.
-async fn establish_tcp_connection(
+async fn establish_tcp_connection<S>(
     address: &str,
     port: u16,
     dns_resolver: Arc<TokioResolver>,
-) -> Result<TcpStream, crate::error::Error> {
-    let mut set: JoinSet<tokio::io::Result<TcpStream>> = JoinSet::new();
+    context: S::ConnectionContext,
+) -> Result<S, crate::error::Error>
+where
+    S: TcpStreamTrait + TcpConnect,
+{
+    let mut set: JoinSet<tokio::io::Result<S>> = JoinSet::new();
 
     let socket_addrs = to_socket_addrs(address, port, dns_resolver).await?;
 
     for addr in socket_addrs.clone() {
+        let context_clone = context.clone();
         set.spawn(async move {
             log::trace!("SMTP client: connecting to {addr}...");
-            let stream =
-                tokio::time::timeout(Duration::from_secs(60), TcpStream::connect(addr)).await??;
+            let stream: S =
+                tokio::time::timeout(Duration::from_secs(60), S::connect(addr, context_clone))
+                    .await??;
             stream.set_nodelay(true)?;
             Ok(stream)
         });
     }
-    let mut stream: Option<TcpStream> = None;
+    let mut stream: Option<S> = None;
     while let Some(result) = set.join_next().await {
         match result {
             Ok(Ok(s)) => {
@@ -227,46 +241,60 @@ async fn establish_tcp_connection(
     }
 }
 
+/// SMTP/LMTP client configuration options.
+pub struct ClientConfig<'a> {
+    /// Client hostname used for greeting
+    pub client_hostname: &'a str,
+
+    /// If [`Some`], the connection will be upgraded to TLS.
+    /// The client will fail early if the server does not support STARTTLS.
+    pub tls_config: Option<TlsConfig>,
+
+    /// If `true`, switches to `LHLO` greeting and returns per-recipient composite response.
+    pub lmtp: bool,
+}
+
 /// Sends an email using an SMTP server at `smtp_addr`.
-///
-/// If `tls_config` is provided, the connection will be upgraded to TLS.
-/// The client will fail early if the server does not support STARTTLS.
-///
 /// If `address` is a domain that resolves to multiple IP addresses,
 /// all will be tried in parallel and the first successful connection will be used.
 ///
 /// `pool` is used to reuse existing connections to the same address and port, if available.
-pub async fn send(
+pub async fn send<S>(
     address: &str,
     port: u16,
     envelope: &Envelope,
-    client_hostname: &str,
-    tls_config: Option<TlsConfig>,
+    config: ClientConfig<'_>,
     dns_resolver: Arc<TokioResolver>,
-    pool: Arc<SmtpConnectionPool>,
-) -> Result<(), crate::error::Error> {
-    let (mut buf_stream, reused, mut pipelining) = if let Some(connection) =
-        pool.take(address, port).await
-    {
-        log::debug!(
-            "Reusing existing connection to {}",
-            connection.stream.get_ref().format_host(address)
-        );
-        if tls_config.is_some() {
-            // This should never happen,
-            // assert to make sure we never accidentally use a plain connection while expecting TLS.
-            assert!(
-                matches!(connection.stream.get_ref(), SmtpStream::Tls(_)),
-                "Expected TLS stream from pool, but got plain stream."
+    pool: Arc<SmtpConnectionPool<S>>,
+) -> Result<(), crate::error::Error>
+where
+    S: TcpStreamTrait + TcpConnect,
+{
+    let greeting = if config.lmtp { "LHLO" } else { "EHLO" };
+
+    let (mut buf_stream, reused, mut pipelining) =
+        if let Some(connection) = pool.take(address, port).await {
+            log::debug!(
+                "Reusing existing connection to {}",
+                connection.stream.get_ref().format_host(address)
             );
-        }
-        (connection.stream, true, connection.pipelining)
-    } else {
-        let stream =
-            SmtpStream::plain(establish_tcp_connection(address, port, dns_resolver.clone()).await?);
-        log::debug!("Successfully connected to {}", stream.format_host(address));
-        (BufStream::new(stream), false, false)
-    };
+            if config.tls_config.is_some() {
+                // This should never happen,
+                // assert to make sure we never accidentally use a plain connection while expecting TLS.
+                assert!(
+                    matches!(connection.stream.get_ref(), SmtpStream::Tls(_)),
+                    "Expected TLS stream from pool, but got plain stream."
+                );
+            }
+            (connection.stream, true, connection.pipelining)
+        } else {
+            let stream = SmtpStream::plain(
+                establish_tcp_connection(address, port, dns_resolver.clone(), pool.context.clone())
+                    .await?,
+            );
+            log::debug!("Successfully connected to {}", stream.format_host(address));
+            (BufStream::new(stream), false, false)
+        };
 
     let mut response = String::new();
 
@@ -329,7 +357,8 @@ pub async fn send(
         // e.g.: 421 example.org Service closing transmission channel - command timeout
         if response.starts_with("421") {
             log::debug!("Reused connection is dead; establishing new connection...");
-            let stream = establish_tcp_connection(address, port, dns_resolver).await?;
+            let stream: S =
+                establish_tcp_connection(address, port, dns_resolver, pool.context.clone()).await?;
             log::debug!("Successfully connected to {}", stream.peer_addr()?);
             buf_stream = BufStream::new(SmtpStream::plain(stream));
             false
@@ -346,8 +375,8 @@ pub async fn send(
         smtp_read!("initial greeting", "220")?;
 
         smtp_cmd!(
-            format!("EHLO {client_hostname}\r\n").as_bytes(),
-            "EHLO",
+            format!("{greeting} {}\r\n", { config.client_hostname }).as_bytes(),
+            greeting,
             "250"
         )?;
 
@@ -358,7 +387,7 @@ pub async fn send(
         }
 
         // ESMTP: STARTTLS
-        if let Some(tls_config) = tls_config {
+        if let Some(tls_config) = config.tls_config {
             if !response.to_uppercase().contains("STARTTLS") {
                 // TLS was requested, but server doesn't support STARTTLS.
                 return Err(crate::error::Error::MailSend {
@@ -392,7 +421,7 @@ pub async fn send(
             buf_stream = BufStream::new(smtp_stream);
 
             smtp_cmd!(
-                format!("EHLO {client_hostname}\r\n").as_bytes(),
+                format!("EHLO {}\r\n", config.client_hostname).as_bytes(),
                 "EHLO after STARTTLS",
                 "250"
             )?;
@@ -457,7 +486,14 @@ pub async fn send(
     }
 
     smtp_write!(&envelope.data);
-    smtp_cmd!(b".\r\n", "end of DATA", "250")?;
+    smtp_write!(b".\r\n");
+    if config.lmtp {
+        for _ in 0..envelope.rcpt_to.len() {
+            smtp_read!("end of DATA", "250")?;
+        }
+    } else {
+        smtp_read!("end of DATA", "250")?;
+    }
 
     pool.put(
         address,
@@ -477,6 +513,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use std::net::SocketAddr;
+    use tokio::net::TcpStream;
 
     #[rstest]
     #[case::ipv4("192.0.2.0:25".parse().ok(), "192.0.2.0", "192.0.2.0:25")]
@@ -489,7 +526,7 @@ mod tests {
         #[case] host: &str,
         #[case] expected: &str,
     ) {
-        let result = SmtpStream::format_host_inner(host, socket_addr);
+        let result = SmtpStream::<TcpStream>::format_host_inner(host, socket_addr);
         assert_eq!(result, expected);
     }
 }

--- a/src/smtp_responses.rs
+++ b/src/smtp_responses.rs
@@ -1,0 +1,7 @@
+pub const OK_250: &str = "250 OK";
+pub const OK_HTTPS_250: &str = "250 OK (HTTPS)";
+pub const OK_SMTP_250: &str = "250 OK (SMTP)";
+
+pub const ENCRYPTION_NEEDED_523: &str = "523 Encryption Needed: Invalid Unencrypted Mail";
+pub const LOCAL_ERROR_451: &str = "451 Local error";
+pub const WORKER_BUSY_421: &str = "421 Worker for this destination is busy";

--- a/src/smtp_server.rs
+++ b/src/smtp_server.rs
@@ -7,8 +7,8 @@ use memchr::{Memchr, memmem};
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufStream};
+use tokio::net::TcpListener;
 
 /// Represents an SMTP envelope with sender, recipients, and raw message data.
 #[derive(Debug, Default, Clone)]
@@ -139,8 +139,17 @@ pub trait SmtpHandler: Send + Sync {
             log::warn!("Failed to reinject mail: {e}");
             e
         })?;
-        Ok("OK_250".to_string())
+        Ok(OK_250.to_string())
     }
+}
+
+/// A mockup handler that does nothing.
+#[cfg(test)]
+pub struct MockHandler;
+
+#[cfg(test)]
+impl SmtpHandler for MockHandler {
+    type State = ();
 }
 
 /// Runs the SMTP server on the specified address with the given handler and maximum message size.
@@ -164,7 +173,7 @@ where
 
                 let handler = handler.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = handle_connection(socket, handler, max_size).await {
+                    if let Err(e) = handle_connection(socket, handler, max_size, false).await {
                         log::error!("Error handling connection: {e}");
                     }
                 });
@@ -180,27 +189,36 @@ where
 }
 
 /// Handles an individual SMTP connection.
-async fn handle_connection<H>(
-    socket: TcpStream,
+///
+/// Setting `auto_quit` to `true` will automatically close connection after receiving the first
+/// message. Should be used only for tests, it's not a behavior described by SMTP spec.
+pub(crate) async fn handle_connection<S, H>(
+    stream: S,
     handler: Arc<H>,
     max_size: usize,
+    auto_quit: bool,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
+    S: AsyncWrite + AsyncRead + Unpin,
     H: SmtpHandler,
 {
-    let (reader, writer) = socket.into_split();
-    let mut reader = BufReader::new(reader);
-    let mut writer = BufWriter::new(writer);
+    let mut bufstream = BufStream::new(stream);
     let mut line = String::new();
 
-    writer.write_all(b"220 filtermail SMTP\r\n").await?;
-    writer.flush().await?;
+    macro_rules! smtp_write {
+        ($($arg:tt)*) => {
+            bufstream.write_all(format!($($arg)*).as_bytes()).await?;
+            bufstream.flush().await?;
+        };
+    }
+
+    smtp_write!("220 filtermail SMTP\r\n");
 
     let mut transaction = Transaction::default();
 
     'connection: loop {
         line.clear();
-        let n = reader.read_line(&mut line).await?;
+        let n = bufstream.read_line(&mut line).await?;
         if n == 0 {
             break 'connection;
         }
@@ -218,66 +236,50 @@ where
         log::debug!("Received: {cmd}");
 
         if cmd.to_uppercase().starts_with("HELO") {
-            writer.write_all(b"250-filtermail\r\n250 OK\r\n").await?;
-            writer.flush().await?;
+            smtp_write!("250-filtermail\r\n250 OK\r\n");
         } else if cmd.to_uppercase().starts_with("EHLO")
             // We support LMTP, but it's not validated;
             // service that expects LMTP will send LMTP responses no matter the greeting.
             // Sufficient for our internal use case.
             || cmd.to_uppercase().starts_with("LHLO")
         {
-            writer
-                .write_all(b"250-filtermail\r\n250-8BITMIME\r\n250 OK\r\n")
-                .await?;
-            writer.flush().await?;
+            smtp_write!("250-filtermail\r\n250-8BITMIME\r\n250 OK\r\n");
         } else if cmd.to_uppercase().starts_with("MAIL FROM:<>") {
             // bounce message
             transaction.envelope.mail_from = String::new();
-            writer.write_all(format!("{OK_250}\r\n").as_bytes()).await?;
-            writer.flush().await?;
+            smtp_write!("{OK_250}\r\n");
         } else if cmd.to_uppercase().starts_with("MAIL FROM:") {
             if let Some(from) = extract_address(cmd) {
                 if let Err(e) = handler.handle_mail_from(&from) {
-                    writer.write_all(format!("{}\r\n", e).as_bytes()).await?;
-                    writer.flush().await?;
+                    smtp_write!("{}\r\n", e);
                     continue 'connection;
                 }
                 transaction.envelope.mail_from = from;
-                writer.write_all(format!("{OK_250}\r\n").as_bytes()).await?;
-                writer.flush().await?;
+                smtp_write!("{OK_250}\r\n");
             } else {
                 log::warn!("Invalid MAIL FROM command. Can't extract address. Received: {cmd}");
-                writer
-                    .write_all(b"500 Invalid address in MAIL FROM\r\n")
-                    .await?;
-                writer.flush().await?;
+                smtp_write!("500 Invalid address in MAIL FROM\r\n");
             }
         } else if cmd.to_uppercase().starts_with("RCPT TO:") {
             if let Some(to) = extract_address(cmd) {
                 if let Err(e) = handler.handle_rcpt_to(&to, &mut transaction) {
-                    writer.write_all(format!("{}\r\n", e).as_bytes()).await?;
-                    writer.flush().await?;
+                    smtp_write!("{}\r\n", e);
                     continue 'connection;
                 }
                 transaction.envelope.rcpt_to.push(to);
-                writer.write_all(format!("{OK_250}\r\n").as_bytes()).await?;
-                writer.flush().await?;
+                smtp_write!("{OK_250}\r\n");
             }
         } else if cmd.to_uppercase().starts_with("DATA") {
             if let Err(e) = handler.handle_data_start(&transaction) {
-                writer.write_all(format!("{}\r\n", e).as_bytes()).await?;
-                writer.flush().await?;
+                smtp_write!("{}\r\n", e);
                 continue 'connection;
             }
-            writer
-                .write_all(b"354 End data with <CR><LF>.<CR><LF>\r\n")
-                .await?;
-            writer.flush().await?;
+            smtp_write!("354 End data with <CR><LF>.<CR><LF>\r\n");
             let mut data = Vec::new();
             let mut data_line = String::new();
             'data_read: loop {
                 data_line.clear();
-                if reader.read_line(&mut data_line).await? == 0 {
+                if bufstream.read_line(&mut data_line).await? == 0 {
                     log::warn!("Unexpected EoF while receiving DATA! Closing connection.");
                     break 'connection;
                 }
@@ -303,10 +305,7 @@ where
                 data.extend_from_slice(data_line.as_bytes());
 
                 if data.len() > max_size {
-                    writer
-                        .write_all(b"552 Message exceeds maximum size\r\n")
-                        .await?;
-                    writer.flush().await?;
+                    smtp_write!("552 Message exceeds maximum size\r\n");
                     continue 'connection;
                 }
             }
@@ -317,33 +316,27 @@ where
             match handler.handle_data_dot(&mut transaction).await {
                 Ok(response) => {
                     log::debug!("Sent: {response}");
-                    writer
-                        .write_all(format!("{}\r\n", response).as_bytes())
-                        .await?;
-                    writer.flush().await?;
+                    smtp_write!("{}\r\n", response);
                 }
                 Err(e) => {
                     log::debug!("Sent: {e}");
-                    writer.write_all(format!("{}\r\n", e).as_bytes()).await?;
-                    writer.flush().await?;
+                    smtp_write!("{}\r\n", e);
                 }
             }
-
+            if auto_quit {
+                break 'connection;
+            }
             transaction = Transaction::default();
         } else if cmd.to_uppercase().starts_with("QUIT") {
-            writer.write_all(b"221 OK\r\n").await?;
-            writer.flush().await?;
+            smtp_write!("221 OK\r\n");
             break 'connection;
         } else if cmd.to_uppercase().starts_with("RSET") {
             transaction = Transaction::default();
-            writer.write_all(format!("{OK_250}\r\n").as_bytes()).await?;
-            writer.flush().await?;
+            smtp_write!("{OK_250}\r\n");
         } else if cmd.to_uppercase().starts_with("NOOP") {
-            writer.write_all(format!("{OK_250}\r\n").as_bytes()).await?;
-            writer.flush().await?;
+            smtp_write!("{OK_250}\r\n");
         } else {
-            writer.write_all(b"500 Command not recognized\r\n").await?;
-            writer.flush().await?;
+            smtp_write!("500 Command not recognized\r\n");
         }
     }
 

--- a/src/smtp_server.rs
+++ b/src/smtp_server.rs
@@ -1,8 +1,10 @@
 //! A simplified SMTP server implementation for internal communication.
 
+use crate::smtp_responses::OK_250;
 use crate::utils::{extract_address, log_eml};
 use async_trait::async_trait;
 use memchr::{Memchr, memmem};
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
@@ -12,9 +14,7 @@ use tokio::net::{TcpListener, TcpStream};
 #[derive(Debug, Default, Clone)]
 pub struct Envelope {
     pub mail_from: String,
-    pub origin_ip: String,
     pub rcpt_to: Vec<String>,
-
     /// Mail data as transmitted over SMTP/LMTP.
     ///
     /// Described in <https://www.rfc-editor.org/rfc/rfc5321.html#section-2.3.9>.
@@ -23,6 +23,16 @@ pub struct Envelope {
     /// and have all `<CRLF>.` sequences escaped with `.` according to
     /// <https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.2>.
     pub data: Vec<u8>,
+}
+
+/// Represent an ongoing SMTP transaction.
+///
+/// Every new connection starts with an empty envelope and handler state.
+/// A RSET command starts a new transaction, which clears the envelope and state.
+#[derive(Debug, Default)]
+pub struct Transaction<S: Debug + Default> {
+    pub envelope: Envelope,
+    pub state: S,
 }
 
 /// Checks if mail data is valid.
@@ -59,19 +69,55 @@ fn is_valid_data(data: &[u8]) -> bool {
 /// Trait defining the SMTP handler interface.
 #[async_trait]
 pub trait SmtpHandler: Send + Sync {
-    /// Handles the MAIL FROM command.
-    fn handle_mail(&self, address: &str) -> Result<(), String>;
+    /// Transaction state type associated with this handler.
+    type State: Debug + Default + Send;
 
     /// Checks the DATA command before reinjection.
     ///
     /// Can optionally modify the envelope before reinjection.
-    async fn check_data(&self, envelope: &mut Envelope) -> Result<(), String>;
+    ///
+    /// Default implementation is no-op.
+    async fn check_data(&self, _transaction: &mut Transaction<Self::State>) -> Result<(), String> {
+        Ok(())
+    }
 
     /// Reinjects the mail back to postfix.
-    async fn reinject_mail(&self, envelope: &Envelope) -> Result<(), String>;
+    ///
+    /// Default implementation is no-op.
+    async fn reinject_mail(&self, _transaction: &Transaction<Self::State>) -> Result<(), String> {
+        Ok(())
+    }
 
-    /// Handles the DATA command.
-    async fn handle_data(&self, envelope: &mut Envelope) -> Result<String, String> {
+    /// Handles the MAIL FROM command.
+    ///
+    /// Default implementation is no-op.
+    fn handle_mail_from(&self, _address: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// Handles the RCPT TO command.
+    ///
+    /// Default implementation is no-op.
+    fn handle_rcpt_to(
+        &self,
+        _address: &str,
+        _transaction: &mut Transaction<Self::State>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// Handles the DATA command. Called after receiving DATA, before receiving actual data.
+    ///
+    /// Default implementation is no-op.
+    fn handle_data_start(&self, _transaction: &Transaction<Self::State>) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// Handles the end of DATA command. Called after receiving the final dot.
+    async fn handle_data_dot(
+        &self,
+        transaction: &mut Transaction<Self::State>,
+    ) -> Result<String, String> {
         log::debug!("handle_DATA before-queue");
 
         // Check if the DATA is valid
@@ -80,20 +126,20 @@ pub trait SmtpHandler: Send + Sync {
         // We are not going to normalize newlines
         // and escape the dots in the mail data.
         // If mail data turned out to be invalid, reject immediately.
-        if !is_valid_data(&envelope.data) {
+        if !is_valid_data(&transaction.envelope.data) {
             return Err("500 Invalid DATA".to_string());
         }
 
-        self.check_data(envelope).await?;
-        if envelope.rcpt_to.is_empty() {
+        self.check_data(transaction).await?;
+        if transaction.envelope.rcpt_to.is_empty() {
             log::warn!("Dropping mail; All recipients disabled.");
-            return Ok("250 OK".to_string());
+            return Ok(OK_250.to_string());
         }
-        self.reinject_mail(envelope).await.map_err(|e| {
+        self.reinject_mail(transaction).await.map_err(|e| {
             log::warn!("Failed to reinject mail: {e}");
             e
         })?;
-        Ok("250 OK".to_string())
+        Ok("OK_250".to_string())
     }
 }
 
@@ -150,7 +196,7 @@ where
     writer.write_all(b"220 filtermail SMTP\r\n").await?;
     writer.flush().await?;
 
-    let mut envelope = Envelope::default();
+    let mut transaction = Transaction::default();
 
     'connection: loop {
         line.clear();
@@ -181,28 +227,24 @@ where
             || cmd.to_uppercase().starts_with("LHLO")
         {
             writer
-                .write_all(b"250-filtermail\r\n250-XFORWARD ADDR\r\n250-8BITMIME\r\n250 OK\r\n")
+                .write_all(b"250-filtermail\r\n250-8BITMIME\r\n250 OK\r\n")
                 .await?;
             writer.flush().await?;
         } else if cmd.to_uppercase().starts_with("MAIL FROM:<>") {
             // bounce message
-            envelope.mail_from = String::new();
-            writer.write_all(b"250 OK\r\n").await?;
+            transaction.envelope.mail_from = String::new();
+            writer.write_all(format!("{OK_250}\r\n").as_bytes()).await?;
             writer.flush().await?;
         } else if cmd.to_uppercase().starts_with("MAIL FROM:") {
             if let Some(from) = extract_address(cmd) {
-                match handler.handle_mail(&from) {
-                    Ok(_) => {
-                        envelope.mail_from = from;
-                        writer.write_all(b"250 OK\r\n").await?;
-                        writer.flush().await?;
-                    }
-                    Err(e) => {
-                        writer.write_all(format!("{}\r\n", e).as_bytes()).await?;
-                        writer.flush().await?;
-                        break 'connection;
-                    }
+                if let Err(e) = handler.handle_mail_from(&from) {
+                    writer.write_all(format!("{}\r\n", e).as_bytes()).await?;
+                    writer.flush().await?;
+                    continue 'connection;
                 }
+                transaction.envelope.mail_from = from;
+                writer.write_all(format!("{OK_250}\r\n").as_bytes()).await?;
+                writer.flush().await?;
             } else {
                 log::warn!("Invalid MAIL FROM command. Can't extract address. Received: {cmd}");
                 writer
@@ -212,11 +254,21 @@ where
             }
         } else if cmd.to_uppercase().starts_with("RCPT TO:") {
             if let Some(to) = extract_address(cmd) {
-                envelope.rcpt_to.push(to);
-                writer.write_all(b"250 OK\r\n").await?;
+                if let Err(e) = handler.handle_rcpt_to(&to, &mut transaction) {
+                    writer.write_all(format!("{}\r\n", e).as_bytes()).await?;
+                    writer.flush().await?;
+                    continue 'connection;
+                }
+                transaction.envelope.rcpt_to.push(to);
+                writer.write_all(format!("{OK_250}\r\n").as_bytes()).await?;
                 writer.flush().await?;
             }
         } else if cmd.to_uppercase().starts_with("DATA") {
+            if let Err(e) = handler.handle_data_start(&transaction) {
+                writer.write_all(format!("{}\r\n", e).as_bytes()).await?;
+                writer.flush().await?;
+                continue 'connection;
+            }
             writer
                 .write_all(b"354 End data with <CR><LF>.<CR><LF>\r\n")
                 .await?;
@@ -255,14 +307,14 @@ where
                         .write_all(b"552 Message exceeds maximum size\r\n")
                         .await?;
                     writer.flush().await?;
-                    break 'connection;
+                    continue 'connection;
                 }
             }
 
-            envelope.data = data;
+            transaction.envelope.data = data;
 
             // Process the message
-            match handler.handle_data(&mut envelope).await {
+            match handler.handle_data_dot(&mut transaction).await {
                 Ok(response) => {
                     log::debug!("Sent: {response}");
                     writer
@@ -277,29 +329,17 @@ where
                 }
             }
 
-            envelope = Envelope::default();
-        } else if cmd.to_uppercase().starts_with("XFORWARD") {
-            // https://www.postfix.org/XFORWARD_README.html
-            if let Some(addr_part) = cmd
-                .split_whitespace()
-                .find(|part| part.to_uppercase().starts_with("ADDR="))
-                && let Some(ip) = addr_part.strip_prefix("ADDR=")
-            {
-                let ip = ip.to_lowercase();
-                envelope.origin_ip = ip.strip_prefix("ipv6:").unwrap_or(&ip).to_string();
-                writer.write_all(b"250 OK\r\n").await?;
-                writer.flush().await?;
-            }
+            transaction = Transaction::default();
         } else if cmd.to_uppercase().starts_with("QUIT") {
             writer.write_all(b"221 OK\r\n").await?;
             writer.flush().await?;
             break 'connection;
         } else if cmd.to_uppercase().starts_with("RSET") {
-            envelope = Envelope::default();
-            writer.write_all(b"250 OK\r\n").await?;
+            transaction = Transaction::default();
+            writer.write_all(format!("{OK_250}\r\n").as_bytes()).await?;
             writer.flush().await?;
         } else if cmd.to_uppercase().starts_with("NOOP") {
-            writer.write_all(b"250 OK\r\n").await?;
+            writer.write_all(format!("{OK_250}\r\n").as_bytes()).await?;
             writer.flush().await?;
         } else {
             writer.write_all(b"500 Command not recognized\r\n").await?;

--- a/src/snapshots/filtermail__transport__tests__smtp_send_mail.snap
+++ b/src/snapshots/filtermail__transport__tests__smtp_send_mail.snap
@@ -1,0 +1,64 @@
+---
+source: src/transport.rs
+expression: "format!(\"[postfix -> filtermail-transport]\\r\\n{record}\\r\\n\\\n            [filtermail-transport -> destination A]\\r\\n{}\\r\\n\\\n            [filtermail-transport -> destination B]\\r\\n{}\",\nremote_records[0], remote_records[1])"
+---
+[postfix -> filtermail-transport]
+< 220 filtermail SMTP
+> LHLO postfix
+< 250-filtermail
+250-8BITMIME
+250 OK
+> MAIL FROM:<sender@here>
+< 250 OK
+> RCPT TO:<a1@localhost>
+< 250 OK
+> RCPT TO:<a2@localhost>
+< 250 OK
+> RCPT TO:<b1@[127.0.0.1]>
+< 250 OK
+> RCPT TO:<b2@[127.0.0.1]>
+< 250 OK
+> DATA
+< 354 End data with <CR><LF>.<CR><LF>
+> message
+> .
+< 250 OK (SMTP)
+250 OK (SMTP)
+250 OK (SMTP)
+250 OK (SMTP)
+
+[filtermail-transport -> destination A]
+< 220 filtermail SMTP
+> EHLO example.org
+< 250-filtermail
+250-8BITMIME
+250 OK
+> MAIL FROM:<sender@here>
+< 250 OK
+> RCPT TO:<a1@localhost>
+< 250 OK
+> RCPT TO:<a2@localhost>
+< 250 OK
+> DATA
+< 354 End data with <CR><LF>.<CR><LF>
+> message
+.
+< 250 OK
+
+[filtermail-transport -> destination B]
+< 220 filtermail SMTP
+> EHLO example.org
+< 250-filtermail
+250-8BITMIME
+250 OK
+> MAIL FROM:<sender@here>
+< 250 OK
+> RCPT TO:<b1@[127.0.0.1]>
+< 250 OK
+> RCPT TO:<b2@[127.0.0.1]>
+< 250 OK
+> DATA
+< 354 End data with <CR><LF>.<CR><LF>
+> message
+.
+< 250 OK

--- a/src/snapshots/filtermail__transport__tests__smtp_send_mail_defer.snap
+++ b/src/snapshots/filtermail__transport__tests__smtp_send_mail_defer.snap
@@ -1,0 +1,73 @@
+---
+source: src/transport.rs
+expression: "format!(\"TRANSACTION 1\\r\\n\\\n            [postfix -> filtermail-transport]\\r\\n{record_postfix_1}\\r\\n\\\n            [filtermail-transport -> destination A]\\r\\n{record_filtermail_1}\\r\\n\\r\\n\\\n            TRANSACTION 2\\r\\n\\\n            [postfix -> filtermail-transport]\\r\\n{record_postfix_2}\\r\\n\\\n            [filtermail-transport -> destination B]\\r\\n{record_filtermail_2}\",)"
+---
+TRANSACTION 1
+[postfix -> filtermail-transport]
+< 220 filtermail SMTP
+> LHLO postfix
+< 250-filtermail
+250-8BITMIME
+250 OK
+> MAIL FROM:<sender@here>
+< 250 OK
+> RCPT TO:<a1@localhost>
+< 250 OK
+> RCPT TO:<b1@[127.0.0.1]>
+< 250 OK
+> DATA
+< 354 End data with <CR><LF>.<CR><LF>
+> message
+> .
+< 250 OK (SMTP)
+421 Worker for this destination is busy
+
+[filtermail-transport -> destination A]
+< 220 filtermail SMTP
+> EHLO example.org
+< 250-filtermail
+250-8BITMIME
+250 OK
+> MAIL FROM:<sender@here>
+< 250 OK
+> RCPT TO:<a1@localhost>
+< 250 OK
+> DATA
+< 354 End data with <CR><LF>.<CR><LF>
+> message
+.
+< 250 OK
+
+
+TRANSACTION 2
+[postfix -> filtermail-transport]
+< 220 filtermail SMTP
+> LHLO postfix
+< 250-filtermail
+250-8BITMIME
+250 OK
+> MAIL FROM:<sender@here>
+< 250 OK
+> RCPT TO:<b1@[127.0.0.1]>
+< 250 OK
+> DATA
+< 354 End data with <CR><LF>.<CR><LF>
+> message
+> .
+< 250 OK (SMTP)
+
+[filtermail-transport -> destination B]
+< 220 filtermail SMTP
+> EHLO example.org
+< 250-filtermail
+250-8BITMIME
+250 OK
+> MAIL FROM:<sender@here>
+< 250 OK
+> RCPT TO:<b1@[127.0.0.1]>
+< 250 OK
+> DATA
+< 354 End data with <CR><LF>.<CR><LF>
+> message
+.
+< 250 OK

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,0 +1,59 @@
+//! TCP related code.
+
+use async_trait::async_trait;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::{TcpStream, ToSocketAddrs};
+
+#[cfg(test)]
+pub mod rec_stream;
+
+/// Abstraction over [`TcpStream`] allowing e.g. mocking it.
+pub trait TcpStreamTrait: AsyncRead + AsyncWrite + Unpin + Send + Sync + Sized + 'static {
+    /// Returns the remote address that this stream is connected to.
+    fn peer_addr(&self) -> std::io::Result<std::net::SocketAddr>;
+
+    /// Sets the value of the `TCP_NODELAY` option on this socket.
+    fn set_nodelay(&self, nodelay: bool) -> std::io::Result<()>;
+}
+
+/// Trait adding a `connect` method similar to [`TcpStream::connect`],
+/// that allows passing additional context when creating the stream.
+#[async_trait]
+pub trait TcpConnect: TcpStreamTrait {
+    /// Type of additional context passed to [`TcpConnect::connect`].
+    type ConnectionContext: Send + Sync + Clone + 'static;
+
+    /// Opens a TCP connection to a remote host.
+    async fn connect<A: ToSocketAddrs + Send>(
+        addr: A,
+        context: Self::ConnectionContext,
+    ) -> std::io::Result<Self>;
+}
+
+impl TcpStreamTrait for TcpStream {
+    /// Returns the remote address that this stream is connected to.
+    ///
+    /// Delegates to [`TcpStream::peer_addr`].
+    fn peer_addr(&self) -> std::io::Result<std::net::SocketAddr> {
+        TcpStream::peer_addr(self)
+    }
+
+    /// Sets the value of the `TCP_NODELAY` option on this socket.
+    ///
+    /// Delegates to [`TcpStream::set_nodelay`].
+    fn set_nodelay(&self, nodelay: bool) -> std::io::Result<()> {
+        TcpStream::set_nodelay(self, nodelay)
+    }
+}
+
+#[async_trait]
+impl TcpConnect for TcpStream {
+    type ConnectionContext = ();
+
+    /// Opens a TCP connection to a remote host.
+    ///
+    /// Delegates to [`TcpStream::connect`].
+    async fn connect<A: ToSocketAddrs + Send>(addr: A, _: ()) -> std::io::Result<Self> {
+        TcpStream::connect(addr).await
+    }
+}

--- a/src/tcp/rec_stream.rs
+++ b/src/tcp/rec_stream.rs
@@ -1,0 +1,127 @@
+//! [`TcpStreamTrait`] implementation that records communication.
+//!
+//! Used for snapshot testing.
+
+use super::{TcpConnect, TcpStreamTrait};
+use async_trait::async_trait;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::{TcpStream, ToSocketAddrs};
+use tokio::sync::mpsc::Sender;
+
+/// A stream that behaves similarly to [`TcpStream`],
+/// but additionally records the whole conversation to internal buffer,
+/// and sends it over [`Sender`] when dropped.
+pub struct RecTcpStream {
+    tx: Sender<String>,
+    inner: TcpStream,
+    rec_buffer: String,
+    // read/write arrows
+    arrows: (char, char),
+}
+
+impl RecTcpStream {
+    /// Creates a new [`RecTcpStream`].
+    ///
+    /// Recorded conversation will be sent over `tx`.
+    ///
+    /// Setting `is_server` to `true`, will invert read/write arrow characters,
+    /// so that they correctly used for `> client command` and `< server response`.
+    pub fn new(stream: TcpStream, tx: Sender<String>, is_server: bool) -> Self {
+        Self {
+            tx,
+            inner: stream,
+            rec_buffer: String::new(),
+            arrows: match is_server {
+                true => ('>', '<'),
+                false => ('<', '>'),
+            },
+        }
+    }
+}
+
+impl AsyncWrite for RecTcpStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let mut_self = self.get_mut();
+        let inner_result = Pin::new(&mut mut_self.inner).poll_write(cx, buf);
+        if inner_result.is_pending() {
+            return inner_result;
+        }
+
+        if !buf.is_empty() {
+            let mut data = String::from_utf8_lossy(buf).to_string();
+            data = format!("{} {data}", mut_self.arrows.1);
+            mut_self.rec_buffer.push_str(&data);
+        }
+
+        inner_result
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}
+
+impl AsyncRead for RecTcpStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let mut_self = self.get_mut();
+        let inner_result = Pin::new(&mut mut_self.inner).poll_read(cx, buf);
+        if inner_result.is_pending() {
+            return inner_result;
+        }
+
+        let filled = buf.filled();
+        if !filled.is_empty() {
+            let mut data = String::from_utf8_lossy(filled).to_string();
+            data = format!("{} {data}", mut_self.arrows.0);
+            mut_self.rec_buffer.push_str(&data);
+        }
+
+        inner_result
+    }
+}
+
+impl Drop for RecTcpStream {
+    fn drop(&mut self) {
+        let tx = self.tx.clone();
+        let rec_buffer = self.rec_buffer.clone();
+        tokio::spawn(async move { tx.send(rec_buffer).await.unwrap() });
+    }
+}
+
+impl TcpStreamTrait for RecTcpStream {
+    fn peer_addr(&self) -> std::io::Result<SocketAddr> {
+        self.inner.peer_addr()
+    }
+
+    fn set_nodelay(&self, nodelay: bool) -> std::io::Result<()> {
+        self.inner.set_nodelay(nodelay)
+    }
+}
+
+#[async_trait]
+impl TcpConnect for RecTcpStream {
+    type ConnectionContext = Sender<String>;
+
+    async fn connect<A: ToSocketAddrs + Send>(
+        addr: A,
+        tx: Sender<String>,
+    ) -> std::io::Result<Self> {
+        let inner = TcpStream::connect(addr).await?;
+        Ok(Self::new(inner, tx, false))
+    }
+}

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -68,10 +68,7 @@ where
             return Ok(());
         }
 
-        log::trace!(
-            "Trying to acquire a permit for {} worker...",
-            domain.as_ref()
-        );
+        log::trace!("Trying to acquire a permit for {domain} worker...",);
         if let Some(permit) = self.workers.get_permit(&domain) {
             transaction.state.permits.insert(domain, permit);
         }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4,6 +4,7 @@ mod worker;
 use crate::config::Config;
 use crate::smtp_responses::{LOCAL_ERROR_451, WORKER_BUSY_421};
 use crate::smtp_server::{SmtpHandler, Transaction};
+use crate::tcp::{TcpConnect, TcpStreamTrait};
 use crate::utils::AddressDomain;
 use async_trait::async_trait;
 use std::collections::BTreeMap;
@@ -15,11 +16,15 @@ use worker::{WorkerMessage, WorkerPool};
 pub const HEADER_MAIL_FROM: &str = "X-MAIL-FROM";
 pub const HEADER_RCPT_TO: &str = "X-MAIL-TO";
 
-pub struct TransportHandler {
-    workers: WorkerPool,
+pub struct TransportHandler<S: TcpConnect> {
+    workers: WorkerPool<S>,
 }
 
-impl TransportHandler {
+impl<S> TransportHandler<S>
+where
+    S: TcpStreamTrait + TcpConnect,
+    S::ConnectionContext: Default,
+{
     /// Creates a new [`TransportHandler`].
     pub fn new(config: Config) -> Result<Self, crate::error::Error> {
         let workers = WorkerPool::new(config)?;
@@ -44,7 +49,11 @@ pub struct TransactionState {
 }
 
 #[async_trait]
-impl SmtpHandler for TransportHandler {
+impl<S> SmtpHandler for TransportHandler<S>
+where
+    S: TcpStreamTrait + TcpConnect,
+    S::ConnectionContext: Default,
+{
     type State = TransactionState;
 
     fn handle_rcpt_to(
@@ -190,8 +199,90 @@ impl SmtpHandler for TransportHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::smtp_client::SmtpConnectionPool;
+    use crate::smtp_server::{Envelope, MockHandler, run_smtp_server};
+    use crate::tcp::rec_stream::RecTcpStream;
     use rstest::{fixture, rstest};
+    use serial_test::serial;
+    use std::sync::Arc;
+    use std::time::Duration;
     use testresult::TestResult;
+    use tokio::net::{TcpSocket, TcpStream};
+    use tokio::sync::mpsc::Receiver;
+
+    const FILTERMAIL_IP: &str = "127.0.0.1";
+    const FILTERMAIL_PORT: u16 = 10083;
+    const FILTERMAIL_ADDR: (&str, u16) = (FILTERMAIL_IP, FILTERMAIL_PORT);
+
+    /// Spawns a mockup SMTP server that accepts anything on `localhost:10025`.
+    ///
+    /// Returns a receiver that receives records of SMTP conversations.
+    fn spawn_mock_mta() -> TestResult<Receiver<String>> {
+        let socket = TcpSocket::new_v4()?;
+        socket.set_nodelay(true)?;
+        socket.set_reuseport(true)?;
+        socket.bind("127.0.0.1:10025".parse()?)?;
+        let remote_listener = socket.listen(8)?;
+        let (tx, rx) = tokio::sync::mpsc::channel(128);
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = remote_listener.accept().await {
+                let tx_clone = tx.clone();
+                let rec_stream = RecTcpStream::new(stream, tx_clone, true);
+                tokio::spawn(async move {
+                    crate::smtp_server::handle_connection(
+                        rec_stream,
+                        Arc::new(MockHandler),
+                        9999, // arbitrary
+                        true,
+                    )
+                    .await
+                    .unwrap();
+                });
+            }
+        });
+        Ok(rx)
+    }
+
+    /// Spawns filtermail-transport.
+    ///
+    /// Returns a pointer to the underlying handler.
+    fn spawn_filtermail_transport() -> TestResult<Arc<TransportHandler<TcpStream>>> {
+        let config = Config::default();
+        let transport = Arc::new(TransportHandler::with_queue_size(config.clone(), 1)?);
+        tokio::spawn(run_smtp_server(
+            &FILTERMAIL_ADDR,
+            transport.clone(),
+            config.max_message_size,
+        ));
+        Ok(transport)
+    }
+
+    /// Sends envelope over LMTP.
+    ///
+    /// Returns a recorded LMTP conversation.
+    ///
+    /// Does not fail on negative response.
+    async fn lmtp_send(envelope: &Envelope) -> TestResult<String> {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(128);
+        let client_config = crate::smtp_client::ClientConfig {
+            client_hostname: "postfix",
+            tls_config: None,
+            lmtp: true,
+        };
+        let _ = crate::smtp_client::send(
+            FILTERMAIL_IP,
+            FILTERMAIL_PORT,
+            envelope,
+            client_config,
+            Arc::new(crate::utils::build_resolver()?),
+            SmtpConnectionPool::<RecTcpStream>::new(tx),
+        )
+        .await;
+
+        let record = rx.recv().await.unwrap();
+
+        Ok(record)
+    }
 
     #[fixture]
     fn addrs1() -> Vec<String> {
@@ -214,7 +305,8 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_rcpt_to_and_start_data(addrs1: Vec<String>, addrs2: Vec<String>) -> TestResult {
-        let transport_handler = TransportHandler::with_queue_size(Config::default(), 1)?;
+        let transport_handler =
+            TransportHandler::<TcpStream>::with_queue_size(Config::default(), 1)?;
         let domain1 = AddressDomain::from_str(addrs1.first().unwrap())?;
         let domain2 = AddressDomain::from_str(addrs2.first().unwrap())?;
 
@@ -260,6 +352,92 @@ mod tests {
         transport_handler.handle_rcpt_to(addrs2.first().unwrap(), &mut trans_4)?;
         assert!(trans_4.state.permits.contains_key(&domain1));
         assert!(trans_4.state.permits.contains_key(&domain2));
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[serial]
+    #[tokio::test]
+    async fn test_smtp_send_mail() -> TestResult {
+        let mut remote_mta = spawn_mock_mta()?;
+        spawn_filtermail_transport()?;
+
+        let envelope = Envelope {
+            mail_from: "sender@here".to_string(),
+            rcpt_to: vec![
+                // Taking advantage of the fact that localhost and [127.0.0.1] are recognized as
+                // different destinations.
+                "a1@localhost".to_string(),
+                "a2@localhost".to_string(),
+                "b1@[127.0.0.1]".to_string(),
+                "b2@[127.0.0.1]".to_string(),
+            ],
+            data: "message\r\n".as_bytes().to_vec(),
+        };
+
+        let record = lmtp_send(&envelope).await?;
+
+        let mut remote_records = [
+            remote_mta.recv().await.unwrap(),
+            remote_mta.recv().await.unwrap(),
+        ];
+        remote_records.sort_by_key(|s| s.contains("b1@[127.0.0.1]"));
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(remote_mta.is_empty());
+
+        insta::assert_snapshot!(format!(
+            "[postfix -> filtermail-transport]\r\n{record}\r\n\
+            [filtermail-transport -> destination A]\r\n{}\r\n\
+            [filtermail-transport -> destination B]\r\n{}",
+            remote_records[0], remote_records[1]
+        ));
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[serial]
+    #[tokio::test]
+    async fn test_smtp_send_mail_defer() -> TestResult {
+        let mut remote_mta = spawn_mock_mta()?;
+        let transport = spawn_filtermail_transport()?;
+
+        let mut envelope = Envelope {
+            mail_from: "sender@here".to_string(),
+            rcpt_to: vec!["a1@localhost".to_string(), "b1@[127.0.0.1]".to_string()],
+            data: "message\r\n".as_bytes().to_vec(),
+        };
+
+        let (record_postfix_1, record_filtermail_1) = {
+            // simulate full queue on [127.0.0.1] worker
+            let _permit = transport
+                .workers
+                .get_permit(&AddressDomain::Literal("127.0.0.1".to_string()));
+
+            let record_postfix = lmtp_send(&envelope).await?;
+
+            let record_filtermail = remote_mta.recv().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            assert!(remote_mta.is_empty());
+            (record_postfix, record_filtermail)
+        };
+
+        // retry deferred
+        envelope.rcpt_to.remove(0);
+        let record_postfix_2 = lmtp_send(&envelope).await?;
+        let record_filtermail_2 = remote_mta.recv().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(remote_mta.is_empty());
+
+        insta::assert_snapshot!(format!(
+            "TRANSACTION 1\r\n\
+            [postfix -> filtermail-transport]\r\n{record_postfix_1}\r\n\
+            [filtermail-transport -> destination A]\r\n{record_filtermail_1}\r\n\r\n\
+            TRANSACTION 2\r\n\
+            [postfix -> filtermail-transport]\r\n{record_postfix_2}\r\n\
+            [filtermail-transport -> destination B]\r\n{record_filtermail_2}",
+        ));
 
         Ok(())
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,375 +1,112 @@
+mod https_client;
+mod worker;
+
 use crate::config::Config;
-use crate::smtp_client::{SmtpConnectionPool, TlsConfig};
-use crate::smtp_server::{Envelope, SmtpHandler};
-use crate::tls;
-use crate::utils::{AddressDomain, build_resolver};
+use crate::smtp_responses::{LOCAL_ERROR_451, WORKER_BUSY_421};
+use crate::smtp_server::{SmtpHandler, Transaction};
+use crate::utils::AddressDomain;
 use async_trait::async_trait;
-use hickory_resolver::{TokioResolver, proto::rr::RData};
-use http_body_util::BodyExt;
-use hyper::body::Bytes;
-use hyper_rustls::HttpsConnector;
-use hyper_util::client::legacy::connect::HttpConnector;
 use std::collections::BTreeMap;
 use std::str::FromStr;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::task::{JoinHandle, JoinSet};
-use tokio_rustls::rustls;
+use tokio::sync::mpsc::OwnedPermit;
+use tokio::task::JoinSet;
+use worker::{WorkerMessage, WorkerPool};
 
 pub const HEADER_MAIL_FROM: &str = "X-MAIL-FROM";
 pub const HEADER_RCPT_TO: &str = "X-MAIL-TO";
 
-/// Cheaply clonable HTTPS client.
-///
-/// Holds regular secure variant and relaxed - without certificate verification.
-///
-/// Connection pool handled internally by [`hyper_util::client::legacy::Client`].
-#[derive(Clone)]
-struct HttpsClient {
-    pub secure: hyper_util::client::legacy::Client<
-        HttpsConnector<HttpConnector>,
-        http_body_util::Full<Bytes>,
-    >,
-    pub relaxed: hyper_util::client::legacy::Client<
-        HttpsConnector<HttpConnector>,
-        http_body_util::Full<Bytes>,
-    >,
-}
-
-impl HttpsClient {
-    /// Creates a new `[HttpsClient]`.
-    pub fn new(
-        tls_resumption_store: Arc<rustls::client::ClientSessionMemoryCache>,
-    ) -> Result<Self, crate::error::Error> {
-        let tls_client_config = tls::configure_rustls(tls_resumption_store.clone(), false)?;
-        let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_tls_config(tls_client_config)
-            .https_only()
-            .enable_http1()
-            .enable_http2()
-            .build();
-        let https_client =
-            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                .build(https_connector);
-
-        let tls_client_config_relaxed = tls::configure_rustls(tls_resumption_store, true)?;
-        let https_connector_relaxed = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_tls_config(tls_client_config_relaxed)
-            .https_only()
-            .enable_http1()
-            .enable_http2()
-            .build();
-        let https_client_relaxed =
-            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                .build(https_connector_relaxed);
-
-        Ok(Self {
-            secure: https_client,
-            relaxed: https_client_relaxed,
-        })
-    }
-}
-
 pub struct TransportHandler {
-    config: Config,
-    dns_resolver: Arc<TokioResolver>,
-    tls_resumption_store: Arc<rustls::client::ClientSessionMemoryCache>,
-    smtp_connection_pool: Arc<SmtpConnectionPool>,
-    https_client: HttpsClient,
-    mxdeliv_unsupported_hosts: Arc<retainer::Cache<String, bool>>,
-    monitor_handle: JoinHandle<()>,
+    workers: WorkerPool,
 }
 
 impl TransportHandler {
+    /// Creates a new [`TransportHandler`].
     pub fn new(config: Config) -> Result<Self, crate::error::Error> {
-        let dns_resolver = Arc::new(build_resolver()?);
-        let tls_resumption_store = Arc::new(rustls::client::ClientSessionMemoryCache::new(256));
-        let https_client = HttpsClient::new(tls_resumption_store.clone())?;
+        let workers = WorkerPool::new(config)?;
 
-        let mxdeliv_cache = Arc::new(retainer::Cache::new());
-        let mxdeliv_cache_clone = mxdeliv_cache.clone();
-
-        let monitor_handle = tokio::spawn(async move {
-            mxdeliv_cache_clone
-                .monitor(4, 0.25, Duration::from_secs(10))
-                .await
-        });
-
-        Ok(Self {
-            config,
-            dns_resolver,
-            tls_resumption_store,
-            smtp_connection_pool: SmtpConnectionPool::new(),
-            https_client,
-            mxdeliv_unsupported_hosts: mxdeliv_cache,
-            monitor_handle,
-        })
+        Ok(Self { workers })
     }
 
-    /// Handles a single email transaction for a single recipient domain.
-    #[expect(clippy::too_many_arguments)]
-    async fn handle_single_domain(
-        tls_resumption_store: Arc<rustls::client::ClientSessionMemoryCache>,
-        smtp_connection_pool: Arc<SmtpConnectionPool>,
-        mxdeliv_unsupported_hosts: Arc<retainer::Cache<String, bool>>,
-        https_client: HttpsClient,
-        dns_resolver: Arc<TokioResolver>,
-        domain: AddressDomain,
-        envelope: Envelope,
-        client_hostname: String,
-    ) -> Result<String, String> {
-        let mut allow_invalid_cert = false;
-        let mut skip_tls = false; // only respected by smtp channel
-
-        let mx_hosts = match domain {
-            // no-DNS setup; assume the ip from email address is the destination.
-            AddressDomain::Literal(ip) => {
-                // We allow self-signed certs on IP-based relays.
-                allow_invalid_cert = true;
-                vec![(0, ip)]
-            }
-            AddressDomain::Name(mx_domain) => {
-                if mx_domain.eq_ignore_ascii_case("nauta.cu") {
-                    // Special case; We don't want to defederate nauta.cu,
-                    // which doesn't support STARTTLS at all.
-                    skip_tls = true;
-                } else if mx_domain.starts_with('_') {
-                    // We use domains starting with `_` for test deployments.
-                    // (You can't request a non-wildcard cert for such domain)
-                    allow_invalid_cert = true;
-                }
-                let query = format!("{mx_domain}.");
-
-                match dns_resolver.mx_lookup(query).await {
-                    Ok(mx_records) => {
-                        let mut hosts: Vec<(u16, String)> = Vec::new();
-                        for mx_record in mx_records.answers() {
-                            let mx = match mx_record.data {
-                                RData::MX(ref mx) => mx,
-                                _ => continue,
-                            };
-
-                            // Null MX / RFC7505
-                            if mx.exchange.is_root() {
-                                // From RFC7505 section 3:
-                                // > A domain that advertises a null MX MUST NOT
-                                // > advertise any other MX RR.
-                                // We assume this is the only record and exit early.
-                                return Err(
-                                    "556 5.1.10 Permanent failure: Recipient address has null MX"
-                                        .to_string(),
-                                );
-                            }
-
-                            let host = mx.exchange.to_string().trim_end_matches('.').to_string();
-                            hosts.push((mx.preference, host))
-                        }
-                        hosts.sort();
-                        hosts
-                    }
-                    Err(e) => {
-                        if e.is_no_records_found() {
-                            // "implicit MX" as described by section 5.1 of RFC5321
-                            // https://datatracker.ietf.org/doc/html/rfc5321#section-5.1
-                            log::debug!("No MX record found, using implicit MX: {mx_domain}");
-                            vec![(0, mx_domain)]
-                        } else if e.is_nx_domain() {
-                            return Err(format!("512 Domain {mx_domain} does not exist"));
-                        } else {
-                            return Err(format!("421 DNS resolution failed for {mx_domain}"));
-                        }
-                    }
-                }
-            }
-        };
-
-        let tls_config = match skip_tls {
-            true => None,
-            false => Some(TlsConfig {
-                allow_invalid_cert,
-                session_cache: tls_resumption_store,
-            }),
-        };
-
-        let mut last_error = None;
-
-        // we try sequentially in order of MX preference,
-        // but the IPv4 and IPv6 connections (after `smtp_client::send` resolves mx hostname)
-        // happens in parallel.
-        'try_relay: for (_, mx_host) in mx_hosts {
-            let skip_mxdeliv = mxdeliv_unsupported_hosts
-                .get(&mx_host)
-                .await
-                .map(|guard| *guard.value())
-                .unwrap_or(false);
-
-            // HTTPS channel
-            if skip_mxdeliv {
-                log::debug!("Skipping HTTP delivery to host that failed recently: {mx_host}");
-            } else {
-                match Self::https_delivery(
-                    https_client.clone(),
-                    mx_host.clone(),
-                    &envelope,
-                    allow_invalid_cert,
-                )
-                .await
-                {
-                    Ok(_) => {
-                        return Ok("250 Ok (HTTPS)".to_string());
-                    }
-                    Err(e) => {
-                        log::debug!("HTTPS delivery to {mx_host} failed: {e}");
-                    }
-                }
-            }
-
-            // SMTP channel (fallback)
-            match crate::smtp_client::send(
-                &mx_host,
-                25,
-                &envelope,
-                &client_hostname,
-                tls_config.clone(),
-                dns_resolver.clone(),
-                smtp_connection_pool.clone(),
-            )
-            .await
-            {
-                Ok(_) => {
-                    // Switches this host to SMTP for 30 minutes.
-                    // Note: this MUST happen only after a successful SMTP delivery,
-                    // or otherwise any http error will lock us out of any way to
-                    // deliver to a relay with a blocked port 25 for 30 minutes.
-                    mxdeliv_unsupported_hosts
-                        .insert(mx_host.clone(), true, Duration::from_mins(30))
-                        .await;
-                    return Ok("250 Ok (SMTP)".to_string());
-                }
-                Err(error) => {
-                    match &error {
-                        // We only want to try other MX hosts if we encounter a problem
-                        // related to connection.
-                        // (So we don't spam other servers if the message is actually rejected.)
-                        crate::error::Error::Io(_)
-                        | crate::error::Error::ConnectionFailed(_)
-                        | crate::error::Error::Tls(_) => {
-                            // Make sure we quickly retry HTTP if SMTP failed to connect
-                            mxdeliv_unsupported_hosts.remove(&mx_host).await;
-                            log::warn!(
-                                "Connection error relaying to mail server {mx_host}: {error}"
-                            );
-                            last_error = Some((error.smtp_response(), mx_host.clone()));
-                            continue 'try_relay;
-                        }
-                        crate::error::Error::MailSend { .. } => {
-                            log::warn!("Message rejected by mail server {mx_host}: {error}");
-                            return Err(error.smtp_response());
-                        }
-                        _ => {
-                            log::warn!(
-                                "Unexpected error while delivering to mail server {mx_host}: {error}"
-                            );
-                            return Err(format!(
-                                "{} (while attempting delivery to {mx_host})",
-                                error.smtp_response()
-                            ));
-                        }
-                    }
-                }
-            }
-        }
-
-        let (error, mx_host) = last_error.unwrap_or(("?".to_string(), "?".to_string()));
-        Err(format!(
-            "421 Failed to connect to any mail server; last attempt to {mx_host}: {error}"
-        ))
-    }
-
-    /// Performs mail delivery to `mx_host` over HTTPS.
+    /// Same as [`Self::new`], but lets you set worker queue size.
     ///
-    /// Times out after 60s.
-    async fn https_delivery(
-        https_client: HttpsClient,
-        mx_host: String,
-        envelope: &Envelope,
-        allow_invalid_cert: bool,
-    ) -> Result<(), crate::error::Error> {
-        let request: hyper::Request<http_body_util::Full<Bytes>> = {
-            let mut builder = hyper::Request::builder()
-                .method(hyper::Method::POST)
-                .uri(format!("https://{mx_host}/mxdeliv"));
+    /// Only used for tests.
+    #[cfg(test)]
+    pub fn with_queue_size(config: Config, queue_size: usize) -> Result<Self, crate::error::Error> {
+        let workers = WorkerPool::with_queue_size(config, queue_size)?;
 
-            if !envelope.mail_from.is_empty() {
-                builder = builder.header(HEADER_MAIL_FROM, &envelope.mail_from);
-            }
-
-            for rcpt_to in &envelope.rcpt_to {
-                builder = builder.header(HEADER_RCPT_TO, rcpt_to);
-            }
-
-            builder.body(http_body_util::Full::from(envelope.data.clone()))?
-        };
-
-        let client = if allow_invalid_cert {
-            https_client.relaxed
-        } else {
-            https_client.secure
-        };
-
-        let response = tokio::time::timeout(Duration::from_secs(60), client.request(request))
-            .await
-            .map_err(|_| crate::error::Error::MailSend {
-                context: "HTTPS delivery".to_string(),
-                raw_smtp_answer: "[timeout]".to_string(),
-                host: mx_host.clone(),
-            })??;
-        if response.status().is_success() {
-            Ok(())
-        } else {
-            let response_body = response.collect().await?.to_bytes();
-            Err(crate::error::Error::MailSend {
-                context: "HTTPS delivery".to_string(),
-                raw_smtp_answer: String::from_utf8_lossy(&response_body).into(),
-                host: mx_host,
-            })
-        }
+        Ok(Self { workers })
     }
 }
 
-impl Drop for TransportHandler {
-    fn drop(&mut self) {
-        self.monitor_handle.abort();
-    }
+#[derive(Debug, Default)]
+pub struct TransactionState {
+    permits: BTreeMap<AddressDomain, OwnedPermit<WorkerMessage>>,
 }
 
 #[async_trait]
 impl SmtpHandler for TransportHandler {
-    /// NO-OP
-    fn handle_mail(&self, _: &str) -> Result<(), String> {
+    type State = TransactionState;
+
+    fn handle_rcpt_to(
+        &self,
+        address: &str,
+        transaction: &mut Transaction<Self::State>,
+    ) -> Result<(), String> {
+        let domain = AddressDomain::from_str(address).map_err(|e| e.smtp_response())?;
+
+        if transaction.state.permits.contains_key(&domain) {
+            // We already acquired a permit for this domain
+            return Ok(());
+        }
+
+        log::trace!(
+            "Trying to acquire a permit for {} worker...",
+            domain.as_ref()
+        );
+        if let Some(permit) = self.workers.get_permit(&domain) {
+            transaction.state.permits.insert(domain, permit);
+        }
+
         Ok(())
     }
 
-    /// NO-OP
-    async fn check_data(&self, _: &mut Envelope) -> Result<(), String> {
-        Ok(())
-    }
+    fn handle_data_start(&self, transaction: &Transaction<Self::State>) -> Result<(), String> {
+        // We want to prevent needlessly sending data from postfix to filtermail,
+        // so we fail here if we didn't get any permit.
+        //
+        // Examplary scenario:
+        // Consider destinations A and B, where A is unavailable.
+        // We are sending a message to a group of 1@A, 2@A, 1@B, 2@B.
+        // After handle_rcpt_to on every recipient, we end up with a permit for domain B (A fails).
+        // handle_data_start passes and mail data is transmitted to filtermail.
+        // Delivery to B is performed; 1@B and 2@B receive message and a message to 1@A and 2@A
+        // is deferred.
+        // After some time the message is retried, now we only try to acquire permit for A,
+        // but fail -> empty `transaction.state.permits`
+        // handle_data_start fails and mail data is not sent to filtermail.
+        // This greatly reduces RAM usage, as unavailable destination can cause large numbers of
+        // deferred mails to be constantly retried.
 
-    /// NO-OP
-    async fn reinject_mail(&self, _: &Envelope) -> Result<(), String> {
+        if transaction.state.permits.is_empty() {
+            return Err(WORKER_BUSY_421.to_string());
+        }
+
         Ok(())
     }
 
     /// Handles the DATA command and returns LMTP responses as single string.
     ///
     /// Never returns an error, as LMTP response is composite.
-    async fn handle_data(&self, envelope: &mut Envelope) -> Result<String, String> {
+    async fn handle_data_dot(
+        &self,
+        transaction: &mut Transaction<Self::State>,
+    ) -> Result<String, String> {
         let mut domain_rcpts_map = BTreeMap::new();
 
-        for rcpt in &envelope.rcpt_to {
+        for rcpt in &transaction.envelope.rcpt_to {
             let domain = AddressDomain::from_str(rcpt)
                 // Currently we cancel all transactions if any recipient address is invalid.
-                .map_err(|e| e.lmtp_response(envelope.rcpt_to.len()))?;
+                .map_err(|e| e.lmtp_response(transaction.envelope.rcpt_to.len()))?;
             domain_rcpts_map
                 .entry(domain)
                 .or_insert_with(Vec::new)
@@ -382,40 +119,50 @@ impl SmtpHandler for TransportHandler {
 
         for (rcpt_domain, rcpts) in &domain_rcpts_map {
             let domain_envelope = {
-                let mut envelope = envelope.clone();
+                let mut envelope = transaction.envelope.clone();
                 envelope.rcpt_to = rcpts.clone();
                 envelope
             };
-            let task_id = transactions
-                .spawn(Self::handle_single_domain(
-                    self.tls_resumption_store.clone(),
-                    self.smtp_connection_pool.clone(),
-                    self.mxdeliv_unsupported_hosts.clone(),
-                    self.https_client.clone(),
-                    self.dns_resolver.clone(),
-                    rcpt_domain.clone(),
-                    domain_envelope,
-                    self.config.mail_domain.clone(),
-                ))
-                .id();
-            task_id_domain_map.insert(task_id, rcpt_domain);
+            let receiver_task_id =
+                if let Some(permit) = transaction.state.permits.remove(rcpt_domain) {
+                    let (message, receiver) = WorkerMessage::new(domain_envelope);
+                    permit.send(message);
+                    // todo: receiver timeout?
+                    transactions.spawn(receiver).id()
+                } else {
+                    transactions
+                        .spawn(async move { Ok(Err(WORKER_BUSY_421.to_string())) })
+                        .id()
+                };
+            task_id_domain_map.insert(receiver_task_id, rcpt_domain);
         }
 
         let mut rcpt_response_map = BTreeMap::new();
         while let Some(result) = transactions.join_next_with_id().await {
-            let domain_response = match result {
-                Ok((id, Ok(resp))) | Ok((id, Err(resp))) => {
-                    task_id_domain_map.remove(&id).map(|domain| (domain, resp))
+            let domain = match &result {
+                Ok((id, _)) => task_id_domain_map.remove(id),
+                Err(e) => task_id_domain_map.remove(&e.id()),
+            };
+
+            let smtp_response = match result {
+                Ok((_, Ok(Ok(resp)))) | Ok((_, Ok(Err(resp)))) => resp,
+                Ok((_, Err(e))) => {
+                    log::error!(
+                        "Worker task failed while delivering to {}: {e}",
+                        domain.map(AsRef::as_ref).unwrap_or("<unknown>")
+                    );
+                    LOCAL_ERROR_451.to_string()
                 }
                 Err(e) => {
-                    log::error!("Failed to join task: {e}");
-                    task_id_domain_map
-                        .remove(&e.id())
-                        .map(|domain| (domain, "451 Local error".to_string()))
+                    log::error!(
+                        "Failed to join task while delivering to {}: {e}",
+                        domain.map(AsRef::as_ref).unwrap_or("<unknown>")
+                    );
+                    LOCAL_ERROR_451.to_string()
                 }
             };
 
-            if let Some((domain, smtp_response)) = domain_response
+            if let Some(domain) = domain
                 && let Some(rcpts) = domain_rcpts_map.get(domain)
             {
                 for rcpt in rcpts {
@@ -425,16 +172,95 @@ impl SmtpHandler for TransportHandler {
         }
 
         // compose lmtp response...
-        let ordered_responses: Vec<String> = envelope
+        let ordered_responses: Vec<String> = transaction
+            .envelope
             .rcpt_to
             .iter()
             .map(|rcpt| {
                 rcpt_response_map
                     .remove(rcpt)
-                    .unwrap_or_else(|| "451 Local error".to_string())
+                    .unwrap_or_else(|| LOCAL_ERROR_451.to_string())
             })
             .collect();
 
         Ok(ordered_responses.join("\r\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::{fixture, rstest};
+    use testresult::TestResult;
+
+    #[fixture]
+    fn addrs1() -> Vec<String> {
+        let mut vec = Vec::new();
+        for idx in 0..5 {
+            vec.push(format!("{idx}@one.example.org"))
+        }
+        vec
+    }
+
+    #[fixture]
+    fn addrs2() -> Vec<String> {
+        let mut vec = Vec::new();
+        for idx in 0..5 {
+            vec.push(format!("{idx}@two.example.org"))
+        }
+        vec
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_rcpt_to_and_start_data(addrs1: Vec<String>, addrs2: Vec<String>) -> TestResult {
+        let transport_handler = TransportHandler::with_queue_size(Config::default(), 1)?;
+        let domain1 = AddressDomain::from_str(addrs1.first().unwrap())?;
+        let domain2 = AddressDomain::from_str(addrs2.first().unwrap())?;
+
+        {
+            let mut trans_1 = Transaction::default();
+            let mut trans_2 = Transaction::default();
+            let mut trans_3 = Transaction::default();
+
+            transport_handler.handle_rcpt_to(addrs1.first().unwrap(), &mut trans_1)?;
+            assert!(trans_1.state.permits.contains_key(&domain1));
+
+            // Within one transaction, we only use one worker permit, so queue_size=1 is enough.
+            transport_handler.handle_rcpt_to(addrs1.get(1).unwrap(), &mut trans_1)?;
+            assert!(trans_1.state.permits.contains_key(&domain1));
+
+            // However, a second transaction with the same domain won't get a permit.
+            transport_handler.handle_rcpt_to(addrs1.get(2).unwrap(), &mut trans_2)?;
+            assert!(!trans_2.state.permits.contains_key(&domain1));
+
+            // Different domain will work though, as it uses a separate worker, with its own queue.
+            transport_handler.handle_rcpt_to(addrs2.first().unwrap(), &mut trans_2)?;
+            assert!(trans_2.state.permits.contains_key(&domain2));
+
+            // Third transaction won't get any permits.
+            transport_handler.handle_rcpt_to(addrs1.get(3).unwrap(), &mut trans_3)?;
+            transport_handler.handle_rcpt_to(addrs2.get(2).unwrap(), &mut trans_3)?;
+            assert!(!trans_3.state.permits.contains_key(&domain1));
+            assert!(!trans_3.state.permits.contains_key(&domain2));
+
+            // all permits granted -> accept DATA command
+            assert_eq!(transport_handler.handle_data_start(&trans_1), Ok(()));
+
+            // some permits granted -> accept DATA command
+            assert_eq!(transport_handler.handle_data_start(&trans_2), Ok(()));
+
+            // no permits granted -> reject
+            assert!(transport_handler.handle_data_start(&trans_3).is_err());
+        }
+
+        // Transactions (and owned by them permits) going out of scope frees the queues.
+        let mut trans_4 = Transaction::default();
+        transport_handler.handle_rcpt_to(addrs1.first().unwrap(), &mut trans_4)?;
+        transport_handler.handle_rcpt_to(addrs2.first().unwrap(), &mut trans_4)?;
+        assert!(trans_4.state.permits.contains_key(&domain1));
+        assert!(trans_4.state.permits.contains_key(&domain2));
+
+        Ok(())
     }
 }

--- a/src/transport/https_client.rs
+++ b/src/transport/https_client.rs
@@ -1,0 +1,57 @@
+use crate::tls;
+use hyper::body::Bytes;
+use hyper_rustls::HttpsConnector;
+use hyper_util::client::legacy::connect::HttpConnector;
+use std::sync::Arc;
+use tokio_rustls::rustls;
+
+/// Cheaply clonable HTTPS client.
+///
+/// Holds regular secure variant and relaxed - without certificate verification.
+///
+/// Connection pool handled internally by [`hyper_util::client::legacy::Client`].
+#[derive(Clone)]
+pub(crate) struct HttpsClient {
+    pub secure: hyper_util::client::legacy::Client<
+        HttpsConnector<HttpConnector>,
+        http_body_util::Full<Bytes>,
+    >,
+    pub relaxed: hyper_util::client::legacy::Client<
+        HttpsConnector<HttpConnector>,
+        http_body_util::Full<Bytes>,
+    >,
+}
+
+impl HttpsClient {
+    /// Creates a new `[HttpsClient]`.
+    pub fn new(
+        tls_resumption_store: Arc<rustls::client::ClientSessionMemoryCache>,
+    ) -> Result<Self, crate::error::Error> {
+        let tls_client_config = tls::configure_rustls(tls_resumption_store.clone(), false)?;
+        let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_client_config)
+            .https_only()
+            .enable_http1()
+            .enable_http2()
+            .build();
+        let https_client =
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                .build(https_connector);
+
+        let tls_client_config_relaxed = tls::configure_rustls(tls_resumption_store, true)?;
+        let https_connector_relaxed = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_client_config_relaxed)
+            .https_only()
+            .enable_http1()
+            .enable_http2()
+            .build();
+        let https_client_relaxed =
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                .build(https_connector_relaxed);
+
+        Ok(Self {
+            secure: https_client,
+            relaxed: https_client_relaxed,
+        })
+    }
+}

--- a/src/transport/worker.rs
+++ b/src/transport/worker.rs
@@ -100,10 +100,7 @@ where
             if let Some(w) = &worker
                 && w.handle.is_finished()
             {
-                log::error!(
-                    "Worker for destination {} crashed! Restarting...",
-                    destination.as_ref()
-                );
+                log::error!("Worker for destination {destination} crashed! Restarting...",);
                 worker = None;
                 {
                     let mut map = self.inner.write();
@@ -180,10 +177,7 @@ impl Worker {
             .map(|id| id.to_string())
             .unwrap_or("?".to_string());
 
-        log::info!(
-            "Starting worker {worker_id} for destination {}",
-            destination.as_ref()
-        );
+        log::info!("Starting worker {worker_id} for destination {destination}");
 
         let tls_resumption_store = Arc::new(rustls::client::ClientSessionMemoryCache::new(256));
         let https_client = HttpsClient::new(tls_resumption_store.clone())?;
@@ -206,8 +200,7 @@ impl Worker {
             .await;
             if message.response_tx.send(result).is_err() {
                 log::error!(
-                    "Worker {worker_id} ({}) failed to send response to transport handler.",
-                    destination.as_ref()
+                    "Worker {worker_id} ({destination}) failed to send response to transport handler."
                 );
             };
         }

--- a/src/transport/worker.rs
+++ b/src/transport/worker.rs
@@ -1,0 +1,447 @@
+use crate::config::Config;
+use crate::smtp_client::{SmtpConnectionPool, TlsConfig};
+use crate::smtp_responses::{OK_HTTPS_250, OK_SMTP_250};
+use crate::smtp_server::Envelope;
+use crate::transport::{HEADER_MAIL_FROM, HEADER_RCPT_TO, https_client::HttpsClient};
+use crate::utils::{AddressDomain, build_resolver};
+use hickory_resolver::TokioResolver;
+use hickory_resolver::proto::rr::RData;
+use http_body_util::BodyExt;
+use hyper::body::Bytes;
+use parking_lot::RwLock;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc::OwnedPermit;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task;
+use tokio::task::JoinHandle;
+use tokio_rustls::rustls;
+
+/// Message queue size per [`Worker`].
+///
+/// If a queue to a single destination reaches this limit,
+/// all new messages will be immediately deferred.
+const PER_DESTINATION_QUEUE_SIZE: usize = 30;
+
+type SMTPResponse = Result<String, String>;
+
+pub struct WorkerPool {
+    inner: RwLock<BTreeMap<AddressDomain, Arc<Worker>>>,
+    client_hostname: String,
+    smtp_connection_pool: Arc<SmtpConnectionPool>,
+    mxdeliv_unsupported_hosts: Arc<retainer::Cache<String, ()>>,
+    monitor_handle: JoinHandle<()>,
+    dns_resolver: Arc<TokioResolver>,
+    queue_size: usize,
+}
+
+impl WorkerPool {
+    pub fn new(config: Config) -> Result<Self, crate::error::Error> {
+        let dns_resolver = Arc::new(build_resolver()?);
+
+        let mxdeliv_cache = Arc::new(retainer::Cache::new());
+        let mxdeliv_cache_clone = mxdeliv_cache.clone();
+
+        let monitor_handle = tokio::spawn(async move {
+            mxdeliv_cache_clone
+                .monitor(4, 0.25, Duration::from_secs(10))
+                .await
+        });
+
+        Ok(Self {
+            inner: Default::default(),
+            client_hostname: config.mail_domain,
+            dns_resolver,
+            smtp_connection_pool: SmtpConnectionPool::new(),
+            mxdeliv_unsupported_hosts: mxdeliv_cache,
+            monitor_handle,
+            queue_size: PER_DESTINATION_QUEUE_SIZE,
+        })
+    }
+
+    /// Same as [`Self::new`], but lets you set the size of the queue.
+    ///
+    /// Used only for tests.
+    #[cfg(test)]
+    pub fn with_queue_size(config: Config, queue_size: usize) -> Result<Self, crate::error::Error> {
+        let mut this = Self::new(config)?;
+        this.queue_size = queue_size;
+        Ok(this)
+    }
+
+    fn get_or_create_worker(&self, destination: &AddressDomain) -> Arc<Worker> {
+        // NOTE: these locks are blocking, but critical section here is quite small and
+        // shouldn't cause issues in async code.
+        // NOTE: read() returns a guard that is dropped before the match statement.
+        // This must be ensured or else, the write() line would cause a deadlock.
+        let worker = {
+            let mut worker = {
+                let map = self.inner.read();
+                map.get(destination).cloned()
+            };
+            // Remove (and re-create) worker if it finished/crashed.
+            // In reality, this should never happen.
+            if let Some(w) = &worker
+                && w.handle.is_finished()
+            {
+                log::error!(
+                    "Worker for destination {} crashed! Restarting...",
+                    destination.as_ref()
+                );
+                worker = None;
+                {
+                    let mut map = self.inner.write();
+                    map.remove(destination);
+                }
+            };
+            worker
+        };
+
+        match worker {
+            Some(worker) => worker,
+            None => {
+                // Worker for this destination wasn't spawned yet.
+                let (tx, rx) = mpsc::channel(self.queue_size);
+                let handle = tokio::spawn(Worker::run(
+                    destination.clone(),
+                    rx,
+                    self.client_hostname.clone(),
+                    self.smtp_connection_pool.clone(),
+                    self.mxdeliv_unsupported_hosts.clone(),
+                    self.dns_resolver.clone(),
+                ));
+                log::trace!("Worker {} spawned", handle.id());
+                let worker = Arc::new(Worker { tx, handle });
+
+                self.inner
+                    .write()
+                    .insert(destination.clone(), worker.clone());
+                worker
+            }
+        }
+    }
+
+    /// Tries to get an [`OwnedPermit`] to the worker for specified destination.
+    ///
+    /// Returns [`None`] if the worker's queue is full.
+    pub fn get_permit(&self, destination: &AddressDomain) -> Option<OwnedPermit<WorkerMessage>> {
+        let worker = self.get_or_create_worker(destination);
+        worker.tx.clone().try_reserve_owned().ok()
+    }
+}
+
+impl Drop for WorkerPool {
+    fn drop(&mut self) {
+        self.monitor_handle.abort();
+    }
+}
+
+#[derive(Debug)]
+pub struct Worker {
+    pub tx: mpsc::Sender<WorkerMessage>,
+    handle: JoinHandle<Result<(), crate::error::Error>>,
+}
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+impl Worker {
+    pub async fn run(
+        destination: AddressDomain,
+        mut rx: mpsc::Receiver<WorkerMessage>,
+        client_hostname: String,
+        smtp_connection_pool: Arc<SmtpConnectionPool>,
+        mxdeliv_unsupported_hosts: Arc<retainer::Cache<String, ()>>,
+        dns_resolver: Arc<TokioResolver>,
+    ) -> Result<(), crate::error::Error> {
+        let worker_id = task::try_id()
+            .map(|id| id.to_string())
+            .unwrap_or("?".to_string());
+
+        log::info!(
+            "Starting worker {worker_id} for destination {}",
+            destination.as_ref()
+        );
+
+        let tls_resumption_store = Arc::new(rustls::client::ClientSessionMemoryCache::new(256));
+        let https_client = HttpsClient::new(tls_resumption_store.clone())?;
+
+        while let Some(message) = rx.recv().await {
+            log::trace!(
+                "Worker {worker_id} received a message from {}",
+                message.envelope.mail_from
+            );
+            let result = Self::handle_single_domain(
+                tls_resumption_store.clone(),
+                smtp_connection_pool.clone(),
+                mxdeliv_unsupported_hosts.clone(),
+                https_client.clone(),
+                dns_resolver.clone(),
+                destination.clone(),
+                message.envelope,
+                client_hostname.clone(),
+            )
+            .await;
+            if message.response_tx.send(result).is_err() {
+                log::error!(
+                    "Worker {worker_id} ({}) failed to send response to transport handler.",
+                    destination.as_ref()
+                );
+            };
+        }
+
+        Ok(())
+    }
+
+    /// Handles a single email transaction for a single recipient domain.
+    #[expect(clippy::too_many_arguments)]
+    async fn handle_single_domain(
+        tls_resumption_store: Arc<rustls::client::ClientSessionMemoryCache>,
+        smtp_connection_pool: Arc<SmtpConnectionPool>,
+        mxdeliv_unsupported_hosts: Arc<retainer::Cache<String, ()>>,
+        https_client: HttpsClient,
+        dns_resolver: Arc<TokioResolver>,
+        domain: AddressDomain,
+        envelope: Envelope,
+        client_hostname: String,
+    ) -> Result<String, String> {
+        let mut allow_invalid_cert = false;
+        let mut skip_tls = false; // only respected by smtp channel
+
+        let mx_hosts = match domain {
+            // no-DNS setup; assume the ip from email address is the destination.
+            AddressDomain::Literal(ip) => {
+                // We allow self-signed certs on IP-based relays.
+                allow_invalid_cert = true;
+                vec![(0, ip)]
+            }
+            AddressDomain::Name(mx_domain) => {
+                if mx_domain.eq_ignore_ascii_case("nauta.cu") {
+                    // Special case; We don't want to defederate nauta.cu,
+                    // which doesn't support STARTTLS at all.
+                    skip_tls = true;
+                } else if mx_domain.starts_with('_') {
+                    // We use domains starting with `_` for test deployments.
+                    // (You can't request a non-wildcard cert for such domain)
+                    allow_invalid_cert = true;
+                }
+                let query = format!("{mx_domain}.");
+
+                match dns_resolver.mx_lookup(query).await {
+                    Ok(mx_records) => {
+                        let mut hosts: Vec<(u16, String)> = Vec::new();
+                        for mx_record in mx_records.answers() {
+                            let mx = match mx_record.data {
+                                RData::MX(ref mx) => mx,
+                                _ => continue,
+                            };
+
+                            // Null MX / RFC7505
+                            if mx.exchange.is_root() {
+                                // From RFC7505 section 3:
+                                // > A domain that advertises a null MX MUST NOT
+                                // > advertise any other MX RR.
+                                // We assume this is the only record and exit early.
+                                return Err(
+                                    "556 5.1.10 Permanent failure: Recipient address has null MX"
+                                        .to_string(),
+                                );
+                            }
+
+                            let host = mx.exchange.to_string().trim_end_matches('.').to_string();
+                            hosts.push((mx.preference, host))
+                        }
+                        hosts.sort();
+                        hosts
+                    }
+                    Err(e) => {
+                        if e.is_no_records_found() {
+                            // "implicit MX" as described by section 5.1 of RFC5321
+                            // https://datatracker.ietf.org/doc/html/rfc5321#section-5.1
+                            log::debug!("No MX record found, using implicit MX: {mx_domain}");
+                            vec![(0, mx_domain)]
+                        } else if e.is_nx_domain() {
+                            return Err(format!("512 Domain {mx_domain} does not exist"));
+                        } else {
+                            return Err(format!("421 DNS resolution failed for {mx_domain}"));
+                        }
+                    }
+                }
+            }
+        };
+
+        let tls_config = match skip_tls {
+            true => None,
+            false => Some(TlsConfig {
+                allow_invalid_cert,
+                session_cache: tls_resumption_store,
+            }),
+        };
+
+        let mut last_error = None;
+
+        // we try sequentially in order of MX preference,
+        // but the IPv4 and IPv6 connections (after `smtp_client::send` resolves mx hostname)
+        // happens in parallel.
+        'try_relay: for (_, mx_host) in mx_hosts {
+            let skip_mxdeliv = mxdeliv_unsupported_hosts
+                .get(&mx_host)
+                .await
+                .map(|guard| *guard.value())
+                .is_some();
+
+            // HTTPS channel
+            if skip_mxdeliv {
+                log::debug!("Skipping HTTP delivery to host that failed recently: {mx_host}");
+            } else {
+                match Self::https_delivery(
+                    https_client.clone(),
+                    mx_host.clone(),
+                    &envelope,
+                    allow_invalid_cert,
+                )
+                .await
+                {
+                    Ok(_) => {
+                        return Ok(OK_HTTPS_250.to_string());
+                    }
+                    Err(e) => {
+                        log::debug!("HTTPS delivery to {mx_host} failed: {e}");
+                    }
+                }
+            }
+
+            // SMTP channel (fallback)
+            match crate::smtp_client::send(
+                &mx_host,
+                25,
+                &envelope,
+                &client_hostname,
+                tls_config.clone(),
+                dns_resolver.clone(),
+                smtp_connection_pool.clone(),
+            )
+            .await
+            {
+                Ok(_) => {
+                    // Switches this host to SMTP for 30 minutes.
+                    // Note: this MUST happen only after a successful SMTP delivery,
+                    // or otherwise any http error will lock us out of any way to
+                    // deliver to a relay with a blocked port 25 for 30 minutes.
+                    mxdeliv_unsupported_hosts
+                        .insert(mx_host.clone(), (), Duration::from_mins(30))
+                        .await;
+                    return Ok(OK_SMTP_250.to_string());
+                }
+                Err(error) => {
+                    match &error {
+                        // We only want to try other MX hosts if we encounter a problem
+                        // related to connection.
+                        // (So we don't spam other servers if the message is actually rejected.)
+                        crate::error::Error::Io(_)
+                        | crate::error::Error::ConnectionFailed(_)
+                        | crate::error::Error::Tls(_) => {
+                            // Make sure we quickly retry HTTP if SMTP failed to connect
+                            mxdeliv_unsupported_hosts.remove(&mx_host).await;
+                            log::warn!(
+                                "Connection error relaying to mail server {mx_host}: {error}"
+                            );
+                            last_error = Some((error.smtp_response(), mx_host.clone()));
+                            continue 'try_relay;
+                        }
+                        crate::error::Error::MailSend { .. } => {
+                            log::warn!("Message rejected by mail server {mx_host}: {error}");
+                            return Err(error.smtp_response());
+                        }
+                        _ => {
+                            log::warn!(
+                                "Unexpected error while delivering to mail server {mx_host}: {error}"
+                            );
+                            return Err(format!(
+                                "{} (while attempting delivery to {mx_host})",
+                                error.smtp_response()
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        let (error, mx_host) = last_error.unwrap_or(("?".to_string(), "?".to_string()));
+        Err(format!(
+            "421 Failed to connect to any mail server; last attempt to {mx_host}: {error}"
+        ))
+    }
+
+    /// Performs mail delivery to `mx_host` over HTTPS.
+    ///
+    /// Times out after 60s.
+    async fn https_delivery(
+        https_client: HttpsClient,
+        mx_host: String,
+        envelope: &Envelope,
+        allow_invalid_cert: bool,
+    ) -> Result<(), crate::error::Error> {
+        let request: hyper::Request<http_body_util::Full<Bytes>> = {
+            let mut builder = hyper::Request::builder()
+                .method(hyper::Method::POST)
+                .uri(format!("https://{mx_host}/mxdeliv"));
+
+            if !envelope.mail_from.is_empty() {
+                builder = builder.header(HEADER_MAIL_FROM, &envelope.mail_from);
+            }
+
+            for rcpt_to in &envelope.rcpt_to {
+                builder = builder.header(HEADER_RCPT_TO, rcpt_to);
+            }
+
+            builder.body(http_body_util::Full::from(envelope.data.clone()))?
+        };
+
+        let client = if allow_invalid_cert {
+            https_client.relaxed
+        } else {
+            https_client.secure
+        };
+
+        let response = tokio::time::timeout(Duration::from_secs(60), client.request(request))
+            .await
+            .map_err(|_| crate::error::Error::MailSend {
+                context: "HTTPS delivery".to_string(),
+                raw_smtp_answer: "[timeout]".to_string(),
+                host: mx_host.clone(),
+            })??;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let response_body = response.collect().await?.to_bytes();
+            Err(crate::error::Error::MailSend {
+                context: "HTTPS delivery".to_string(),
+                raw_smtp_answer: String::from_utf8_lossy(&response_body).into(),
+                host: mx_host,
+            })
+        }
+    }
+}
+
+pub struct WorkerMessage {
+    pub envelope: Envelope,
+    pub response_tx: oneshot::Sender<SMTPResponse>,
+}
+
+impl WorkerMessage {
+    pub fn new(envelope: Envelope) -> (Self, oneshot::Receiver<SMTPResponse>) {
+        let (response_tx, response_rx) = oneshot::channel();
+        (
+            Self {
+                envelope,
+                response_tx,
+            },
+            response_rx,
+        )
+    }
+}

--- a/src/transport/worker.rs
+++ b/src/transport/worker.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::smtp_client::{SmtpConnectionPool, TlsConfig};
 use crate::smtp_responses::{OK_HTTPS_250, OK_SMTP_250};
 use crate::smtp_server::Envelope;
+use crate::tcp::{TcpConnect, TcpStreamTrait};
 use crate::transport::{HEADER_MAIL_FROM, HEADER_RCPT_TO, https_client::HttpsClient};
 use crate::utils::{AddressDomain, build_resolver};
 use hickory_resolver::TokioResolver;
@@ -18,6 +19,16 @@ use tokio::task;
 use tokio::task::JoinHandle;
 use tokio_rustls::rustls;
 
+#[cfg(not(test))]
+const SMTP_PORT: u16 = 25;
+#[cfg(not(test))]
+const SMTP_SKIP_TLS: bool = false;
+
+#[cfg(test)]
+const SMTP_PORT: u16 = 10025;
+#[cfg(test)]
+const SMTP_SKIP_TLS: bool = true;
+
 /// Message queue size per [`Worker`].
 ///
 /// If a queue to a single destination reaches this limit,
@@ -26,17 +37,21 @@ const PER_DESTINATION_QUEUE_SIZE: usize = 30;
 
 type SMTPResponse = Result<String, String>;
 
-pub struct WorkerPool {
+pub struct WorkerPool<S: TcpConnect> {
     inner: RwLock<BTreeMap<AddressDomain, Arc<Worker>>>,
     client_hostname: String,
-    smtp_connection_pool: Arc<SmtpConnectionPool>,
+    smtp_connection_pool: Arc<SmtpConnectionPool<S>>,
     mxdeliv_unsupported_hosts: Arc<retainer::Cache<String, ()>>,
     monitor_handle: JoinHandle<()>,
     dns_resolver: Arc<TokioResolver>,
     queue_size: usize,
 }
 
-impl WorkerPool {
+impl<S> WorkerPool<S>
+where
+    S: TcpStreamTrait + TcpConnect,
+    S::ConnectionContext: Default,
+{
     pub fn new(config: Config) -> Result<Self, crate::error::Error> {
         let dns_resolver = Arc::new(build_resolver()?);
 
@@ -53,7 +68,7 @@ impl WorkerPool {
             inner: Default::default(),
             client_hostname: config.mail_domain,
             dns_resolver,
-            smtp_connection_pool: SmtpConnectionPool::new(),
+            smtp_connection_pool: SmtpConnectionPool::<S>::new(Default::default()),
             mxdeliv_unsupported_hosts: mxdeliv_cache,
             monitor_handle,
             queue_size: PER_DESTINATION_QUEUE_SIZE,
@@ -131,7 +146,7 @@ impl WorkerPool {
     }
 }
 
-impl Drop for WorkerPool {
+impl<S: TcpConnect> Drop for WorkerPool<S> {
     fn drop(&mut self) {
         self.monitor_handle.abort();
     }
@@ -150,14 +165,17 @@ impl Drop for Worker {
 }
 
 impl Worker {
-    pub async fn run(
+    pub async fn run<S>(
         destination: AddressDomain,
         mut rx: mpsc::Receiver<WorkerMessage>,
         client_hostname: String,
-        smtp_connection_pool: Arc<SmtpConnectionPool>,
+        smtp_connection_pool: Arc<SmtpConnectionPool<S>>,
         mxdeliv_unsupported_hosts: Arc<retainer::Cache<String, ()>>,
         dns_resolver: Arc<TokioResolver>,
-    ) -> Result<(), crate::error::Error> {
+    ) -> Result<(), crate::error::Error>
+    where
+        S: TcpStreamTrait + TcpConnect,
+    {
         let worker_id = task::try_id()
             .map(|id| id.to_string())
             .unwrap_or("?".to_string());
@@ -199,18 +217,21 @@ impl Worker {
 
     /// Handles a single email transaction for a single recipient domain.
     #[expect(clippy::too_many_arguments)]
-    async fn handle_single_domain(
+    async fn handle_single_domain<S>(
         tls_resumption_store: Arc<rustls::client::ClientSessionMemoryCache>,
-        smtp_connection_pool: Arc<SmtpConnectionPool>,
+        smtp_connection_pool: Arc<SmtpConnectionPool<S>>,
         mxdeliv_unsupported_hosts: Arc<retainer::Cache<String, ()>>,
         https_client: HttpsClient,
         dns_resolver: Arc<TokioResolver>,
         domain: AddressDomain,
         envelope: Envelope,
         client_hostname: String,
-    ) -> Result<String, String> {
+    ) -> Result<String, String>
+    where
+        S: TcpStreamTrait + TcpConnect,
+    {
         let mut allow_invalid_cert = false;
-        let mut skip_tls = false; // only respected by smtp channel
+        let mut skip_tls = SMTP_SKIP_TLS; // only respected by smtp channel
 
         let mx_hosts = match domain {
             // no-DNS setup; assume the ip from email address is the destination.
@@ -316,12 +337,16 @@ impl Worker {
             }
 
             // SMTP channel (fallback)
+            let client_config = crate::smtp_client::ClientConfig {
+                client_hostname: &client_hostname,
+                tls_config: tls_config.clone(),
+                lmtp: false,
+            };
             match crate::smtp_client::send(
                 &mx_host,
-                25,
+                SMTP_PORT,
                 &envelope,
-                &client_hostname,
-                tls_config.clone(),
+                client_config,
                 dns_resolver.clone(),
                 smtp_connection_pool.clone(),
             )

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use hickory_resolver::{TokioResolver, proto::dnssec::TrustAnchors};
 use mailparse::MailAddr;
+use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -88,6 +89,24 @@ impl AsRef<str> for AddressDomain {
     }
 }
 
+impl Display for AddressDomain {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AddressDomain::Literal(addr) => {
+                // naive check, but should be enough as long as `AddressDomain`
+                // is constructed using parse/from_str.
+                write!(f, "[")?;
+                if addr.contains(':') {
+                    write!(f, "IPv6:")?;
+                }
+                write!(f, "{addr}]")?;
+            }
+            AddressDomain::Name(domain) => write!(f, "{domain}")?,
+        };
+        Ok(())
+    }
+}
+
 /// Logs email to `/tmp/filtermail-rejected/<reason>/<timestamp>.eml`
 /// and returns the file path.
 ///
@@ -159,5 +178,21 @@ mod tests {
     fn test_get_domain_from_address(#[case] input: &str, #[case] expected: Option<AddressDomain>) {
         let result = AddressDomain::from_str(input).ok();
         assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    #[case::domain(AddressDomain::Name("example.org".to_string()), "example.org")]
+    #[case::ipv4(AddressDomain::Literal("192.0.2.0".to_string()), "192.0.2.0")]
+    #[case::ipv6(AddressDomain::Literal("2001:db8::1".to_string()), "2001:db8::1")]
+    fn test_address_domain_as_ref(#[case] input: AddressDomain, #[case] expected: &str) {
+        assert_eq!(input.as_ref(), expected);
+    }
+
+    #[rstest]
+    #[case::domain(AddressDomain::Name("example.org".to_string()), "example.org")]
+    #[case::ipv4(AddressDomain::Literal("192.0.2.0".to_string()), "[192.0.2.0]")]
+    #[case::ipv6(AddressDomain::Literal("2001:db8::1".to_string()), "[IPv6:2001:db8::1]")]
+    fn test_address_domain_display(#[case] input: AddressDomain, #[case] expected: &str) {
+        assert_eq!(&format!("{input}"), expected);
     }
 }


### PR DESCRIPTION
Implements a per-destination worker pool,
so that connections to the same destination
are not parallelized, but instead queued.
If a queue is full, new messages are immediately
deferred, before mail data is sent from postfix.

Closes: #141

Signed-off-by: Jagoda Ślązak <jslazak@jslazak.com>