### PR TITLE
feat!: remove passthrough options that allowed unencrypted mail to pass

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuration file handling for filtermail.
 
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use std::net::IpAddr;
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
@@ -30,10 +30,6 @@ pub struct Config {
     pub max_user_send_per_minute: NonZeroU32,
     #[serde(default = "Config::default_max_user_send_burst_size")]
     pub max_user_send_burst_size: NonZeroU32,
-    #[serde(default, deserialize_with = "deserialize_sequence")]
-    pub passthrough_senders: Vec<String>,
-    #[serde(default, deserialize_with = "deserialize_sequence")]
-    pub passthrough_recipients: Vec<String>,
     pub mail_domain: String,
     mailboxes_dir: Option<PathBuf>,
 }
@@ -42,22 +38,6 @@ pub struct Config {
 struct ConfigWrapper {
     // The whole actual config is under `params` section.
     pub params: Config,
-}
-
-/// Custom deserializer to parse space-separated strings into [`Vec<String>`].
-fn deserialize_sequence<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: Option<String> = Deserialize::deserialize(deserializer)?;
-    Ok(match s {
-        Some(v) => v
-            .split(' ')
-            .map(|item| item.trim().to_string())
-            .filter(|item| !item.is_empty())
-            .collect(),
-        None => Vec::new(),
-    })
 }
 
 impl Config {
@@ -156,8 +136,6 @@ impl Default for Config {
             max_message_size: Self::default_max_message_size(),
             max_user_send_per_minute: Self::default_max_user_send_per_minute(),
             max_user_send_burst_size: Self::default_max_user_send_burst_size(),
-            passthrough_senders: Vec::new(),
-            passthrough_recipients: Vec::new(),
             mail_domain: "example.org".to_string(),
             mailboxes_dir: None,
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -131,30 +131,12 @@ pub fn check_encrypted(mail: &mailparse::ParsedMail, outgoing: bool) -> bool {
     true
 }
 
-/// Check if recipient matches a passthrough pattern
-pub fn recipient_matches_passthrough(recipient: &str, passthrough_recipients: &[String]) -> bool {
-    for addr in passthrough_recipients {
-        if recipient == addr {
-            return true;
-        }
-        if addr.starts_with('@') && recipient.ends_with(addr) {
-            return true;
-        }
-    }
-    false
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use mailparse::parse_mail;
     use rstest::*;
     use testresult::TestResult;
-
-    #[fixture]
-    fn passthrough_recipients() -> Vec<String> {
-        vec!["pass@example.org".to_string(), "@example.com".to_string()]
-    }
 
     #[rstest]
     #[case::asm("test_data/asm.eml", false)]
@@ -188,19 +170,5 @@ mod tests {
         let parsed = parse_mail(raw_email.as_bytes())?;
         assert_eq!(check_encrypted(&parsed, false), expected);
         Ok(())
-    }
-
-    #[rstest]
-    #[case("pass@example.org", true)]
-    #[case("other@example.org", false)]
-    #[case("anything@example.com", true)]
-    #[case("anything@sub.example.com", false)]
-    fn test_recipient_matches_passthrough(
-        #[case] recipient: &str,
-        #[case] expected: bool,
-        passthrough_recipients: Vec<String>,
-    ) {
-        let result = recipient_matches_passthrough(recipient, &passthrough_recipients);
-        assert_eq!(result, expected);
     }
 }

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -2,7 +2,7 @@
 
 use crate::ENCRYPTION_NEEDED_523;
 use crate::config::Config;
-use crate::message::{check_encrypted, is_securejoin, recipient_matches_passthrough};
+use crate::message::{check_encrypted, is_securejoin};
 use crate::smtp_client::SmtpConnectionPool;
 pub use crate::smtp_server::Envelope;
 use crate::smtp_server::SmtpHandler;
@@ -114,11 +114,6 @@ impl SmtpHandler for OutgoingBeforeQueueHandler {
 
         log::info!("Outgoing: Filtering unencrypted mail.");
 
-        // Allow passthrough senders
-        if self.config.passthrough_senders.contains(&from_addr) {
-            return Ok(());
-        }
-
         // Allow self-sent Autocrypt Setup Message
         if envelope.rcpt_to.len() == 1
             && let Some(rcpt_to) = envelope.rcpt_to.first()
@@ -133,14 +128,8 @@ impl SmtpHandler for OutgoingBeforeQueueHandler {
             }
         }
 
-        for recipient in &envelope.rcpt_to {
-            if !recipient_matches_passthrough(recipient, &self.config.passthrough_recipients) {
-                log::warn!("Rejected unencrypted mail from: {from_addr}");
-                return Err(ENCRYPTION_NEEDED_523.to_string());
-            }
-        }
-
-        Ok(())
+        log::warn!("Rejected unencrypted mail from: {from_addr}");
+        Err(ENCRYPTION_NEEDED_523.to_string())
     }
 
     async fn reinject_mail(&self, envelope: &Envelope) -> Result<(), String> {


### PR DESCRIPTION
see https://github.com/chatmail/relay/pull/970/ for the related removal of chatmail.ini options