### PR TITLE
feat: switch to aws-lc-rs cryptography provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +194,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -199,6 +224,15 @@ checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
 dependencies = [
  "base64",
  "encoding_rs",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -396,6 +430,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +609,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -796,6 +842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "bitflags",
  "cfg-if",
  "data-encoding",
@@ -809,7 +856,6 @@ dependencies = [
  "lru-cache",
  "parking_lot",
  "rand 0.10.1",
- "ring",
  "rustls-pki-types",
  "thiserror",
  "time",
@@ -825,6 +871,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
+ "aws-lc-rs",
  "bitflags",
  "data-encoding",
  "idna 1.1.0",
@@ -1205,6 +1252,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1764,7 +1821,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -1845,9 +1902,9 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1869,9 +1926,10 @@ version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2361,6 +2419,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ governor = { version = "0.10.4", default-features = false, features = [
   "dashmap",
 ] }
 viadkim = { version = "0.2.0" }
-hickory-resolver = { version = "0.26.1", features = ["dnssec-ring"] }
+hickory-resolver = { version = "0.26.1", features = ["dnssec-aws-lc-rs"] }
 lru = "0.18.0"
 parking_lot = "0.12.5"
 tokio-rustls = { version = "0.26.4", default-features = false, features = [
-  "ring",
+  "aws-lc-rs",
   "logging",
   "tls12",
 ] }
@@ -44,7 +44,7 @@ hyper-util = { version = "0.1.20", features = [
 ] }
 http-body-util = "0.1.3"
 hyper-rustls = { version = "0.27.9", default-features = false, features = [
-  "ring",
+  "aws-lc-rs",
   "http1",
   "http2",
   "logging",

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<(), error::Error> {
         .format_timestamp(None)
         .init();
 
-    tokio_rustls::rustls::crypto::ring::default_provider()
+    tokio_rustls::rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("Failed to set up rustls crypto provider.");
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -16,7 +16,7 @@ pub async fn wrap_rustls<IO>(
 where
     IO: AsyncRead + AsyncWrite + Unpin,
 {
-    let config = configure_rustls(resumption_store, dangerous_no_cert_verification);
+    let config = configure_rustls(resumption_store, dangerous_no_cert_verification)?;
     let tls = tokio_rustls::TlsConnector::from(Arc::new(config));
     let name = rustls::pki_types::ServerName::try_from(hostname)?.to_owned();
     let tls_stream = tls.connect(name, stream).await?;
@@ -26,13 +26,16 @@ where
 pub fn configure_rustls(
     resumption_store: Arc<ClientSessionMemoryCache>,
     dangerous_no_cert_verification: bool,
-) -> rustls::ClientConfig {
+) -> Result<rustls::ClientConfig, crate::error::Error> {
     let root_cert_store =
         rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
-    let mut config = rustls::ClientConfig::builder()
-        .with_root_certificates(root_cert_store)
-        .with_no_client_auth();
+    let mut config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()?
+    .with_root_certificates(root_cert_store)
+    .with_no_client_auth();
 
     // Enable TLS 1.3 session resumption
     // as defined in <https://www.rfc-editor.org/rfc/rfc8446#section-2.2>.
@@ -50,5 +53,5 @@ pub fn configure_rustls(
             .set_certificate_verifier(Arc::new(NoCertificateVerification::default()));
     }
 
-    config
+    Ok(config)
 }

--- a/src/tls/danger.rs
+++ b/src/tls/danger.rs
@@ -24,7 +24,7 @@ impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
         cert: &CertificateDer<'_>,
         dss: &rustls::DigitallySignedStruct,
     ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        let provider = rustls::crypto::ring::default_provider();
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
         let supported_schemes = &provider.signature_verification_algorithms;
         rustls::crypto::verify_tls12_signature(message, cert, dss, supported_schemes)
     }
@@ -35,13 +35,13 @@ impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
         cert: &CertificateDer<'_>,
         dss: &rustls::DigitallySignedStruct,
     ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        let provider = rustls::crypto::ring::default_provider();
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
         let supported_schemes = &provider.signature_verification_algorithms;
         rustls::crypto::verify_tls13_signature(message, cert, dss, supported_schemes)
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        let provider = rustls::crypto::ring::default_provider();
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
         provider
             .signature_verification_algorithms
             .supported_schemes()

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -38,8 +38,10 @@ struct HttpsClient {
 
 impl HttpsClient {
     /// Creates a new `[HttpsClient]`.
-    pub fn new(tls_resumption_store: Arc<rustls::client::ClientSessionMemoryCache>) -> Self {
-        let tls_client_config = tls::configure_rustls(tls_resumption_store.clone(), false);
+    pub fn new(
+        tls_resumption_store: Arc<rustls::client::ClientSessionMemoryCache>,
+    ) -> Result<Self, crate::error::Error> {
+        let tls_client_config = tls::configure_rustls(tls_resumption_store.clone(), false)?;
         let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
             .with_tls_config(tls_client_config)
             .https_only()
@@ -50,7 +52,7 @@ impl HttpsClient {
             hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
                 .build(https_connector);
 
-        let tls_client_config_relaxed = tls::configure_rustls(tls_resumption_store, true);
+        let tls_client_config_relaxed = tls::configure_rustls(tls_resumption_store, true)?;
         let https_connector_relaxed = hyper_rustls::HttpsConnectorBuilder::new()
             .with_tls_config(tls_client_config_relaxed)
             .https_only()
@@ -61,10 +63,10 @@ impl HttpsClient {
             hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
                 .build(https_connector_relaxed);
 
-        Self {
+        Ok(Self {
             secure: https_client,
             relaxed: https_client_relaxed,
-        }
+        })
     }
 }
 
@@ -82,7 +84,7 @@ impl TransportHandler {
     pub fn new(config: Config) -> Result<Self, crate::error::Error> {
         let dns_resolver = Arc::new(build_resolver()?);
         let tls_resumption_store = Arc::new(rustls::client::ClientSessionMemoryCache::new(256));
-        let https_client = HttpsClient::new(tls_resumption_store.clone());
+        let https_client = HttpsClient::new(tls_resumption_store.clone())?;
 
         let mxdeliv_cache = Arc::new(retainer::Cache::new());
         let mxdeliv_cache_clone = mxdeliv_cache.clone();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,3 @@
-use hickory_resolver::config::ResolverOpts;
 use hickory_resolver::{TokioResolver, proto::dnssec::TrustAnchors};
 use mailparse::MailAddr;
 use std::path::PathBuf;


### PR DESCRIPTION
Switches crypto provider to keep
chatmail codebase consistent,
analogous to https://github.com/chatmail/core/pull/8313