### PR TITLE
perf: don't keep multiple copies of the same mail data in memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -575,6 +575,7 @@ version = "0.7.5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
+ "bytes",
  "env_logger",
  "governor",
  "hickory-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ hyper-rustls = { version = "0.27.9", default-features = false, features = [
   "logging",
   "tls12",
 ] }
+bytes = "1.12.1"
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -142,7 +142,7 @@ impl<H: SmtpHandler + 'static> Service<Request<Incoming>> for MxDelivService<H> 
                 }
             };
 
-            transaction.envelope.data = body_bytes.to_vec();
+            transaction.envelope.data = body_bytes;
 
             log::debug!("(HTTP) MAIL FROM:<{}>", transaction.envelope.mail_from);
             for rcpt in &transaction.envelope.rcpt_to {

--- a/src/inbound.rs
+++ b/src/inbound.rs
@@ -187,6 +187,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
     use rstest::{fixture, rstest};
     use testresult::TestResult;
     use tokio::net::TcpStream;
@@ -212,7 +213,7 @@ mod tests {
         let mut transaction = Transaction {
             envelope: Envelope {
                 mail_from: address.to_string(),
-                data: eml.to_vec(),
+                data: Bytes::from_owner(eml.to_vec()),
                 rcpt_to: vec!["does.not.matter@example.org".to_string()],
             },
             ..Default::default()

--- a/src/smtp_server.rs
+++ b/src/smtp_server.rs
@@ -3,6 +3,7 @@
 use crate::smtp_responses::OK_250;
 use crate::utils::{extract_address, log_eml};
 use async_trait::async_trait;
+use bytes::Bytes;
 use memchr::{Memchr, memmem};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -22,7 +23,7 @@ pub struct Envelope {
     /// It MUST end with `<CRLF>`, contain no bare `<CR>` or `<LF>`
     /// and have all `<CRLF>.` sequences escaped with `.` according to
     /// <https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.2>.
-    pub data: Vec<u8>,
+    pub data: Bytes,
 }
 
 /// Represent an ongoing SMTP transaction.
@@ -310,7 +311,7 @@ where
                 }
             }
 
-            transaction.envelope.data = data;
+            transaction.envelope.data = Bytes::from_owner(data);
 
             // Process the message
             match handler.handle_data_dot(&mut transaction).await {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -387,7 +387,7 @@ mod tests {
                 "b1@[127.0.0.1]".to_string(),
                 "b2@[127.0.0.1]".to_string(),
             ],
-            data: "message\r\n".as_bytes().to_vec(),
+            data: "message\r\n".into(),
         };
 
         let record = lmtp_send(&envelope).await?;
@@ -420,7 +420,7 @@ mod tests {
         let mut envelope = Envelope {
             mail_from: "sender@here".to_string(),
             rcpt_to: vec!["a1@localhost".to_string(), "b1@[127.0.0.1]".to_string()],
-            data: "message\r\n".as_bytes().to_vec(),
+            data: "message\r\n".into(),
         };
 
         let (record_postfix_1, record_filtermail_1) = {
@@ -466,13 +466,13 @@ mod tests {
         let envelope_1 = Envelope {
             mail_from: "sender@here".to_string(),
             rcpt_to: vec!["a1@localhost".to_string()],
-            data: "message\r\n".as_bytes().to_vec(),
+            data: "message\r\n".into(),
         };
 
         let envelope_2 = Envelope {
             mail_from: "sender@here".to_string(),
             rcpt_to: vec!["b1@[127.0.0.1]".to_string()],
-            data: "message\r\n".as_bytes().to_vec(),
+            data: "message\r\n".into(),
         };
 
         // 1

--- a/src/transport/worker.rs
+++ b/src/transport/worker.rs
@@ -471,7 +471,7 @@ impl Worker {
                 builder = builder.header(HEADER_RCPT_TO, rcpt_to);
             }
 
-            builder.body(http_body_util::Full::from(envelope.data.clone()))?
+            builder.body(http_body_util::Full::from(envelope.data.to_vec()))?
         };
 
         let client = if allow_invalid_cert {


### PR DESCRIPTION
Uses `Bytes` instead of `Vec<u8>`,
to prevent keeping multiple copies of messages
in memory.