### PR TITLE
perf: don't convert Bytes to Vec

### DIFF
--- a/src/transport/worker.rs
+++ b/src/transport/worker.rs
@@ -471,7 +471,7 @@ impl Worker {
                 builder = builder.header(HEADER_RCPT_TO, rcpt_to);
             }
 
-            builder.body(http_body_util::Full::from(envelope.data.to_vec()))?
+            builder.body(http_body_util::Full::new(envelope.data.clone()))?
         };
 
         let client = if allow_invalid_cert {


### PR DESCRIPTION
Leftover I forgot to remove in #232,
this prevents cloning the inner data.